### PR TITLE
Add Windows service-mode controls and improve Game Filter / launch UI

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -140,6 +140,74 @@ fn run_hidden_cmd_with_args(args: &[&str]) -> Result<(), String> {
     Ok(())
 }
 
+fn get_service_sorted_bat_files(binaries_dir: &PathBuf) -> Result<Vec<String>, String> {
+    let ps_script = format!(
+        "Get-ChildItem -LiteralPath '{}' -Filter '*.bat' | Where-Object {{ $_.Name -notlike 'service*' }} | Sort-Object {{ [Regex]::Replace($_.Name, '(\\d+)', {{ $args[0].Value.PadLeft(8, '0') }}) }} | ForEach-Object {{ $_.Name }}",
+        binaries_dir.to_string_lossy().replace('\'', "''")
+    );
+
+    let out = Command::new("powershell")
+        .args(["-NoProfile", "-Command", &ps_script])
+        .output()
+        .map_err(|e| format!("Не удалось получить список .bat через PowerShell: {}", e))?;
+
+    if !out.status.success() {
+        return Err("PowerShell не смог собрать список .bat файлов".to_string());
+    }
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let files: Vec<String> = stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(|s| s.to_string())
+        .collect();
+
+    if files.is_empty() {
+        return Err("Список стратегий для service.bat пуст".to_string());
+    }
+
+    Ok(files)
+}
+
+fn get_game_filter_mode_from_service_bat(binaries_dir: &PathBuf) -> Option<String> {
+    let service_bat = binaries_dir.join("service.bat");
+    if !service_bat.exists() {
+        return None;
+    }
+
+    let cmdline = format!(
+        "cd /d \"{}\" && call \"{}\" load_game_filter && echo __GF__!GameFilterStatus!__",
+        binaries_dir.to_string_lossy(),
+        service_bat.to_string_lossy()
+    );
+
+    let out = Command::new("cmd")
+        .args(["/v:on", "/c", &cmdline])
+        .output()
+        .ok()?;
+
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let marker_start = "__GF__";
+    let marker_end = "__";
+    let start = stdout.find(marker_start)?;
+    let rest = &stdout[start + marker_start.len()..];
+    let end = rest.find(marker_end)?;
+    let status = rest[..end].trim().to_lowercase();
+
+    if status.contains("tcp and udp") {
+        Some("all".to_string())
+    } else if status.contains("(tcp)") {
+        Some("tcp".to_string())
+    } else if status.contains("(udp)") {
+        Some("udp".to_string())
+    } else if status.contains("disabled") {
+        Some("disabled".to_string())
+    } else {
+        None
+    }
+}
+
 // ─── Commands ─────────────────────────────────────────────────────────────────
 
 /// Список стратегий — имена .bat файлов из binaries/ (без service.bat).
@@ -217,23 +285,26 @@ fn get_service_status() -> ServiceStatus {
 fn get_filters_status() -> FiltersStatus {
     let dir = find_binaries_dir();
 
-    // ── Game Filter: binaries/utils/game_filter.enabled ──
-    let game_flag = dir.join("utils").join("game_filter.enabled");
-    let game_filter = if !game_flag.exists() {
-        "disabled".to_string()
-    } else {
-        let content = std::fs::read_to_string(&game_flag).unwrap_or_default();
-        // Убираем BOM, пробелы, CRLF
-        let mode = content
-            .trim_start_matches('\u{FEFF}')
-            .trim()
-            .to_lowercase();
-        match mode.as_str() {
-            "tcp" => "tcp".to_string(),
-            "udp" => "udp".to_string(),
-            _ => "all".to_string(),
+    // ── Game Filter: приоритетно читаем фактический статус из service.bat ──
+    // Фолбэк — файл binaries/utils/game_filter.enabled.
+    let game_filter = get_game_filter_mode_from_service_bat(&dir).unwrap_or_else(|| {
+        let game_flag = dir.join("utils").join("game_filter.enabled");
+        if !game_flag.exists() {
+            "disabled".to_string()
+        } else {
+            let content = std::fs::read_to_string(&game_flag).unwrap_or_default();
+            // Убираем BOM, пробелы, CRLF
+            let mode = content
+                .trim_start_matches('\u{FEFF}')
+                .trim()
+                .to_lowercase();
+            match mode.as_str() {
+                "tcp" => "tcp".to_string(),
+                "udp" => "udp".to_string(),
+                _ => "all".to_string(),
+            }
         }
-    };
+    });
     let game_filter_label = match game_filter.as_str() {
         "disabled" => "disabled".to_string(),
         "tcp" => "enabled (TCP)".to_string(),
@@ -296,15 +367,8 @@ fn start_zapret_service(strategy: String, state: State<'_, AppState>) -> Result<
         return Err("service.bat не найден в папке binaries".to_string());
     }
 
-    // Индекс стратегии как в service.bat (алфавитная сортировка .bat, без service*)
-    let mut files: Vec<String> = std::fs::read_dir(&binaries_dir)
-        .map_err(|e| format!("Не удалось прочитать binaries: {}", e))?
-        .filter_map(|e| e.ok())
-        .filter_map(|e| e.path().file_name().and_then(|n| n.to_str()).map(|s| s.to_string()))
-        .filter(|name| name.to_ascii_lowercase().ends_with(".bat"))
-        .filter(|name| !name.to_ascii_lowercase().starts_with("service"))
-        .collect();
-    files.sort();
+    // Индекс стратегии как в service.bat (натуральная сортировка через PowerShell).
+    let files = get_service_sorted_bat_files(&binaries_dir)?;
 
     let target = format!("{}.bat", strategy);
     let index = files
@@ -314,8 +378,8 @@ fn start_zapret_service(strategy: String, state: State<'_, AppState>) -> Result<
         .ok_or_else(|| format!("Стратегия не найдена для установки в сервис: {}", strategy))?;
 
     // Автоматизируем меню service.bat:
-    // 1 -> Install Service, далее индекс стратегии, потом 0 -> Exit
-    let automation = format!("echo 1&echo {}&echo 0", index);
+    // 1 -> Install Service, индекс стратегии, Enter для pause, 0 -> Exit
+    let automation = format!("echo 1&echo {}&echo.&echo 0", index);
     let cmdline = format!(
         "cd /d \"{}\" && ({}) | \"{}\" admin",
         binaries_dir.to_string_lossy(),
@@ -323,10 +387,15 @@ fn start_zapret_service(strategy: String, state: State<'_, AppState>) -> Result<
         service_bat.to_string_lossy()
     );
 
-    Command::new("cmd")
+    let out = Command::new("cmd")
         .args(["/c", &cmdline])
         .output()
         .map_err(|e| format!("Не удалось запустить установку сервиса: {}", e))?;
+
+    if !out.status.success() || !is_service_installed("zapret") {
+        let err = String::from_utf8_lossy(&out.stderr);
+        return Err(format!("Не удалось установить сервис. {}", err.trim()));
+    }
 
     *state.active_strategy.lock().unwrap() = Some(strategy);
     Ok("Service mode enabled".into())
@@ -340,16 +409,24 @@ fn remove_zapret_service(state: State<'_, AppState>) -> Result<String, String> {
         return Err("service.bat не найден в папке binaries".to_string());
     }
 
-    // 2 -> Remove Services, 0 -> Exit
+    // 2 -> Remove Services, Enter для pause, 0 -> Exit
     let cmdline = format!(
-        "cd /d \"{}\" && (echo 2&echo 0) | \"{}\" admin",
+        "cd /d \"{}\" && (echo 2&echo.&echo 0) | \"{}\" admin",
         binaries_dir.to_string_lossy(),
         service_bat.to_string_lossy()
     );
-    Command::new("cmd")
+    let out = Command::new("cmd")
         .args(["/c", &cmdline])
         .output()
         .map_err(|e| format!("Не удалось удалить сервис: {}", e))?;
+
+    if !out.status.success() {
+        let err = String::from_utf8_lossy(&out.stderr);
+        return Err(format!("Ошибка удаления сервиса. {}", err.trim()));
+    }
+    if is_service_installed("zapret") {
+        return Err("Сервис zapret всё ещё установлен после попытки удаления".to_string());
+    }
 
     *state.active_strategy.lock().unwrap() = None;
     Ok("Service mode disabled".into())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,11 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Mutex;
 use tauri::State;
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 struct AppState {
     active_strategy: Mutex<Option<String>>,
@@ -19,6 +24,17 @@ struct FiltersStatus {
     game_filter: String,
     /// "none" | "any" | "loaded"
     ipset: String,
+    /// "disabled" | "all" | "tcp" | "udp"
+    game_filter_raw: String,
+    /// Человекочитаемый статус как в service.bat
+    game_filter_label: String,
+}
+
+#[derive(serde::Serialize)]
+struct ServiceStatus {
+    installed: bool,
+    running: bool,
+    strategy: Option<String>,
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -95,6 +111,35 @@ fn get_strategy_from_registry() -> Option<String> {
     None
 }
 
+fn is_service_installed(name: &str) -> bool {
+    Command::new("sc")
+        .args(["query", name])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn is_service_running(name: &str) -> bool {
+    let output = Command::new("sc")
+        .args(["query", name])
+        .output();
+    match output {
+        Ok(out) => String::from_utf8_lossy(&out.stdout).contains("RUNNING"),
+        Err(_) => false,
+    }
+}
+
+fn run_hidden_cmd_with_args(args: &[&str]) -> Result<(), String> {
+    let mut cmd = Command::new("cmd");
+    cmd.args(args);
+    #[cfg(windows)]
+    cmd.creation_flags(CREATE_NO_WINDOW);
+
+    cmd.spawn()
+        .map_err(|e| format!("Не удалось запустить процесс: {}", e))?;
+    Ok(())
+}
+
 // ─── Commands ─────────────────────────────────────────────────────────────────
 
 /// Список стратегий — имена .bat файлов из binaries/ (без service.bat).
@@ -150,6 +195,23 @@ fn get_zapret_status(state: State<'_, AppState>) -> ZapretStatus {
     ZapretStatus { running: true, strategy: from_reg }
 }
 
+#[tauri::command]
+fn get_service_status() -> ServiceStatus {
+    let installed = is_service_installed("zapret");
+    let running = if installed {
+        is_service_running("zapret")
+    } else {
+        false
+    };
+    let strategy = if installed { get_strategy_from_registry() } else { None };
+
+    ServiceStatus {
+        installed,
+        running,
+        strategy,
+    }
+}
+
 /// Состояние Game Filter и IPSet Filter по файлам конфигурации.
 #[tauri::command]
 fn get_filters_status() -> FiltersStatus {
@@ -172,6 +234,12 @@ fn get_filters_status() -> FiltersStatus {
             _ => "all".to_string(),
         }
     };
+    let game_filter_label = match game_filter.as_str() {
+        "disabled" => "disabled".to_string(),
+        "tcp" => "enabled (TCP)".to_string(),
+        "udp" => "enabled (UDP)".to_string(),
+        _ => "enabled (TCP and UDP)".to_string(),
+    };
 
     // ── IPSet Filter: binaries/lists/ipset-all.txt ──
     let ipset_file = dir.join("lists").join("ipset-all.txt");
@@ -189,7 +257,12 @@ fn get_filters_status() -> FiltersStatus {
         }
     };
 
-    FiltersStatus { game_filter, ipset }
+    FiltersStatus {
+        game_filter_raw: game_filter.clone(),
+        game_filter,
+        game_filter_label,
+        ipset,
+    }
 }
 
 /// Запускает стратегию по имени .bat файла.
@@ -208,13 +281,78 @@ fn start_zapret(strategy: String, state: State<'_, AppState>) -> Result<String, 
         .ok_or("Невалидный путь к bat-файлу")?
         .to_string();
 
-    Command::new("cmd")
-        .args(["/c", &bat_str])
-        .spawn()
+    run_hidden_cmd_with_args(&["/c", &bat_str])
         .map_err(|e| format!("Не удалось запустить стратегию: {}", e))?;
 
     *state.active_strategy.lock().unwrap() = Some(strategy);
     Ok("Connected".into())
+}
+
+#[tauri::command]
+fn start_zapret_service(strategy: String, state: State<'_, AppState>) -> Result<String, String> {
+    let binaries_dir = find_binaries_dir();
+    let service_bat = binaries_dir.join("service.bat");
+    if !service_bat.exists() {
+        return Err("service.bat не найден в папке binaries".to_string());
+    }
+
+    // Индекс стратегии как в service.bat (алфавитная сортировка .bat, без service*)
+    let mut files: Vec<String> = std::fs::read_dir(&binaries_dir)
+        .map_err(|e| format!("Не удалось прочитать binaries: {}", e))?
+        .filter_map(|e| e.ok())
+        .filter_map(|e| e.path().file_name().and_then(|n| n.to_str()).map(|s| s.to_string()))
+        .filter(|name| name.to_ascii_lowercase().ends_with(".bat"))
+        .filter(|name| !name.to_ascii_lowercase().starts_with("service"))
+        .collect();
+    files.sort();
+
+    let target = format!("{}.bat", strategy);
+    let index = files
+        .iter()
+        .position(|f| f.eq_ignore_ascii_case(&target))
+        .map(|i| i + 1)
+        .ok_or_else(|| format!("Стратегия не найдена для установки в сервис: {}", strategy))?;
+
+    // Автоматизируем меню service.bat:
+    // 1 -> Install Service, далее индекс стратегии, потом 0 -> Exit
+    let automation = format!("echo 1&echo {}&echo 0", index);
+    let cmdline = format!(
+        "cd /d \"{}\" && ({}) | \"{}\" admin",
+        binaries_dir.to_string_lossy(),
+        automation,
+        service_bat.to_string_lossy()
+    );
+
+    Command::new("cmd")
+        .args(["/c", &cmdline])
+        .output()
+        .map_err(|e| format!("Не удалось запустить установку сервиса: {}", e))?;
+
+    *state.active_strategy.lock().unwrap() = Some(strategy);
+    Ok("Service mode enabled".into())
+}
+
+#[tauri::command]
+fn remove_zapret_service(state: State<'_, AppState>) -> Result<String, String> {
+    let binaries_dir = find_binaries_dir();
+    let service_bat = binaries_dir.join("service.bat");
+    if !service_bat.exists() {
+        return Err("service.bat не найден в папке binaries".to_string());
+    }
+
+    // 2 -> Remove Services, 0 -> Exit
+    let cmdline = format!(
+        "cd /d \"{}\" && (echo 2&echo 0) | \"{}\" admin",
+        binaries_dir.to_string_lossy(),
+        service_bat.to_string_lossy()
+    );
+    Command::new("cmd")
+        .args(["/c", &cmdline])
+        .output()
+        .map_err(|e| format!("Не удалось удалить сервис: {}", e))?;
+
+    *state.active_strategy.lock().unwrap() = None;
+    Ok("Service mode disabled".into())
 }
 
 /// Полностью останавливает zapret.
@@ -268,7 +406,10 @@ pub fn run() {
             get_zapret_status,
             get_filters_status,
             start_zapret,
+            start_zapret_service,
             stop_zapret,
+            remove_zapret_service,
+            get_service_status,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,8 +11,8 @@
     "windows": [
       {
         "title": "zapret-ui",
-        "width": 1000,
-        "height": 700,
+        "width": 1120,
+        "height": 860,
         "resizable": false,
         "maximizable": false
       }

--- a/src/index.html
+++ b/src/index.html
@@ -135,6 +135,26 @@
                             </select>
                         </div>
                     </div>
+
+                    <div class="w-full space-y-3 mb-8 text-left">
+                        <h3 class="font-headline text-[10px] font-bold uppercase tracking-[0.2em] text-primary/70 ml-2">
+                            Launch Mode</h3>
+                        <div class="glass-panel rounded-2xl p-4 border border-primary/10 space-y-2">
+                            <div class="text-[10px] uppercase tracking-[0.2em] text-on-surface-variant">
+                                Service status: <span id="service-status-label">checking…</span>
+                            </div>
+                            <div class="grid grid-cols-2 gap-2">
+                                <button id="service-enable-btn"
+                                    class="w-full py-2 rounded-xl border border-primary/20 text-xs uppercase tracking-wider hover:border-primary/60 transition-colors">
+                                    Enable service
+                                </button>
+                                <button id="temporary-start-btn"
+                                    class="w-full py-2 rounded-xl border border-primary/20 text-xs uppercase tracking-wider hover:border-primary/60 transition-colors">
+                                    Temporary run
+                                </button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
 
                 <button id="connect-btn" data-action="start"
@@ -177,6 +197,7 @@
                 <div class="flex items-center justify-between px-2 h-6">
                     <h3 class="font-headline text-xs font-bold uppercase tracking-[0.2em] text-primary/70">Game Filter
                     </h3>
+                    <span id="game-filter-mode" class="text-[10px] uppercase tracking-[0.2em] text-on-surface-variant">Mode: disabled</span>
                     <button id="game-toggle"
                         class="toggle-btn is-on relative w-12 h-6 flex items-center rounded-full p-1">
                         <div class="toggle-thumb w-4 h-4 bg-primary rounded-full shadow-[0_0_10px_#ba9eff]"></div>

--- a/src/main.js
+++ b/src/main.js
@@ -37,6 +37,8 @@ async function loadStrategies() {
 
 // ─── Статус zapret ────────────────────────────────────────────────────────────
 
+let serviceInstalled = false;
+
 function updateStatusUI(status) {
     const sel = $('strategy-select');
 
@@ -77,12 +79,42 @@ function updateStatusUI(status) {
     }
 }
 
+function updateServiceUI(status) {
+    serviceInstalled = !!status.installed;
+    const label = $('service-status-label');
+    const tempBtn = $('temporary-start-btn');
+    const serviceBtn = $('service-enable-btn');
+
+    if (status.installed) {
+        const mode = status.running ? 'running' : 'installed';
+        const strategy = status.strategy ? ` (${status.strategy})` : '';
+        label.textContent = `${mode}${strategy}`;
+        tempBtn.disabled = true;
+        tempBtn.classList.add('opacity-50', 'cursor-not-allowed');
+        serviceBtn.textContent = 'Disable service';
+    } else {
+        label.textContent = 'disabled';
+        tempBtn.disabled = false;
+        tempBtn.classList.remove('opacity-50', 'cursor-not-allowed');
+        serviceBtn.textContent = 'Enable service';
+    }
+}
+
 async function pollStatus() {
     try {
         const status = await invoke('get_zapret_status');
         updateStatusUI(status);
     } catch (err) {
         console.error('Ошибка опроса статуса:', err);
+    }
+}
+
+async function pollService() {
+    try {
+        const status = await invoke('get_service_status');
+        updateServiceUI(status);
+    } catch (err) {
+        console.error('Ошибка опроса service:', err);
     }
 }
 
@@ -118,11 +150,13 @@ function updateFiltersUI(filters) {
     setCardActive('ipset-any',    filters.ipset === 'any');
 
     // ── Game Filter ──
-    const gameOn = filters.game_filter !== 'disabled';
+    const gameMode = filters.game_filter_raw ?? filters.game_filter;
+    const gameOn = gameMode !== 'disabled';
     setToggle('game-toggle', gameOn);
-    setCardActive('game-all', filters.game_filter === 'all');
-    setCardActive('game-tcp', filters.game_filter === 'tcp');
-    setCardActive('game-udp', filters.game_filter === 'udp');
+    setCardActive('game-all', gameMode === 'all');
+    setCardActive('game-tcp', gameMode === 'tcp');
+    setCardActive('game-udp', gameMode === 'udp');
+    $('game-filter-mode').textContent = `Mode: ${filters.game_filter_label ?? gameMode}`;
 }
 
 async function pollFilters() {
@@ -143,6 +177,11 @@ async function handleConnectClick() {
 
     try {
         if (action === 'start') {
+            if (serviceInstalled) {
+                $('hero-status').textContent = 'Service mode is enabled';
+                $('hero-status').className = 'text-secondary';
+                return;
+            }
             const strategy = $('strategy-select').value;
             if (!strategy) return;
             await invoke('start_zapret', { strategy });
@@ -160,6 +199,38 @@ async function handleConnectClick() {
     }
 }
 
+async function handleServiceToggle() {
+    const btn = $('service-enable-btn');
+    btn.disabled = true;
+    try {
+        const strategy = $('strategy-select').value;
+        if (!serviceInstalled) {
+            if (!strategy) return;
+            await invoke('start_zapret_service', { strategy });
+        } else {
+            await invoke('remove_zapret_service');
+        }
+        await pollService();
+        await pollStatus();
+    } catch (err) {
+        console.error('Ошибка переключения service mode:', err);
+    } finally {
+        btn.disabled = false;
+    }
+}
+
+async function handleTemporaryStart() {
+    if (serviceInstalled) return;
+    const strategy = $('strategy-select').value;
+    if (!strategy) return;
+    try {
+        await invoke('start_zapret', { strategy });
+        await pollStatus();
+    } catch (err) {
+        console.error('Ошибка временного запуска:', err);
+    }
+}
+
 // ─── Инициализация ────────────────────────────────────────────────────────────
 
 window.addEventListener('DOMContentLoaded', async () => {
@@ -167,13 +238,17 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     // Сначала получаем статус — чтобы в dropdown сразу встала активная стратегия
     await pollStatus();
+    await pollService();
     await pollFilters();
 
     // Поллинг каждые 2 секунды
     setInterval(async () => {
         await pollStatus();
+        await pollService();
         await pollFilters();
     }, 2000);
 
     $('connect-btn').addEventListener('click', handleConnectClick);
+    $('service-enable-btn').addEventListener('click', handleServiceToggle);
+    $('temporary-start-btn').addEventListener('click', handleTemporaryStart);
 });

--- a/src/main.js
+++ b/src/main.js
@@ -207,13 +207,19 @@ async function handleServiceToggle() {
         if (!serviceInstalled) {
             if (!strategy) return;
             await invoke('start_zapret_service', { strategy });
+            $('hero-status').textContent = 'Service mode enabled';
+            $('hero-status').className = 'text-secondary';
         } else {
             await invoke('remove_zapret_service');
+            $('hero-status').textContent = 'Service mode disabled';
+            $('hero-status').className = 'text-error-dim';
         }
         await pollService();
         await pollStatus();
     } catch (err) {
         console.error('Ошибка переключения service mode:', err);
+        $('hero-status').textContent = `Service error: ${err}`;
+        $('hero-status').className = 'text-error-dim text-xl';
     } finally {
         btn.disabled = false;
     }


### PR DESCRIPTION
### Motivation
- Provide UI control for two Zapret launch modes (temporary run vs Windows Service) and avoid visible console windows when launching strategies from the app.
- Surface the Game Filter status in the UI exactly like `service.bat` (modes: Disable / TCP and UDP / TCP only / UDP only).

### Description
- Backend: added `get_service_status`, `start_zapret_service`, and `remove_zapret_service` commands and wired them into `invoke_handler` in `src-tauri/src/lib.rs` to detect/install/remove the Windows service and read service strategy from the registry.
- Backend: implemented `run_hidden_cmd_with_args` and use of Windows `CREATE_NO_WINDOW` when launching `cmd` to reduce/avoid an extra visible console when starting a strategy (`start_zapret`).
- Backend: extended `get_filters_status` to return `game_filter_raw` and `game_filter_label` (human-readable label matching `service.bat`) alongside the existing `ipset` state.
- Frontend: added a new Launch Mode panel with `Enable service`/`Disable service` and `Temporary run` buttons, service status label, polling via `get_service_status`, and guards that disable temporary run when service is installed; updated Game Filter UI to use the raw mode and display the label (`src/index.html`, `src/main.js`).

### Testing
- `node --check src/main.js` completed successfully and reported no syntax issues.
- `cargo check` did not complete in this Linux container because system dependency `glib-2.0` / `glib-2.0.pc` is missing, causing the Rust/Tauri build to fail; this is an environment issue rather than a code compile error on Windows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df791985bc8330bd40ceb168b3c664)