### PR TITLE
Extract Flowseal core provider

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,11 +29,15 @@ jobs:
           workspaces: "src-tauri"
           shared-key: "zapret-ui-rust-cache-clippy"
 
+      - name: cargo test
+        working-directory: src-tauri
+        run: cargo test
+
       - name: cargo clippy
         working-directory: src-tauri
-        # Blocking: all pre-existing warnings have been cleaned up, so any new
-        # finding must be addressed in the PR that introduces it.
-        run: cargo clippy --no-deps -- -D warnings
+        # Blocking: check library, binaries, and test targets so test-only
+        # feature/configuration mistakes cannot bypass CI.
+        run: cargo clippy --all-targets --no-deps -- -D warnings
 
   cargo-audit:
     # cargo-audit is pure crate-metadata analysis, so we can run it on Linux

--- a/.gitignore
+++ b/.gitignore
@@ -25,18 +25,17 @@ version.txt
 /logo.ico
 /logo.png
 
-# Local files & Binaries.
-# Everything under binaries/ is either downloaded from the Flowseal upstream at
-# first launch (*.bat, lists/, bin/, utils/) or is user-editable runtime state
-# (*.enabled, user lists). Keep a .gitkeep so the directory exists on clone —
-# `ensure_binaries_present` creates it otherwise, but tooling that expects the
-# folder on fresh checkouts is simpler this way.
+# Local files and downloaded core installations.
 *.local
 .env
 .env.*
 *.backup
-binaries/*
-!binaries/.gitkeep
+/binaries/
+/binaries.previous/
+/.binaries-staging-*/
+/.binaries-previous-backup/
+/.binaries-rollback-swap/
+/.binaries-rollback-restore-swap/
 
 # Editor & OS
 .vscode/*

--- a/core-channel/stable.json
+++ b/core-channel/stable.json
@@ -2,6 +2,14 @@
   "schemaVersion": 1,
   "channel": "stable",
   "provider": "flowseal",
-  "version": "",
-  "artifacts": []
+  "version": "1.10.0",
+  "artifacts": [
+    {
+      "url": "https://github.com/Flowseal/zapret-discord-youtube/releases/download/1.10.0/zapret-discord-youtube-1.10.0.zip",
+      "checksum": {
+        "algorithm": "sha256",
+        "value": "6b7c5a66cfd055b8e361f8b5fb00f00b167260f21b1c03d589f6008417fb94a2"
+      }
+    }
+  ]
 }

--- a/core-channel/stable.json
+++ b/core-channel/stable.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "channel": "stable",
+  "provider": "flowseal",
+  "version": "",
+  "artifacts": []
+}

--- a/docs/core-release-channel.md
+++ b/docs/core-release-channel.md
@@ -1,0 +1,14 @@
+# Managed stable core channel
+
+Core updates are controlled by `core-channel/stable.json`; the application never promotes an upstream Flowseal release automatically. The checked-in manifest is also the offline fallback embedded at compile time.
+
+## Promotion
+
+1. Select a Flowseal release candidate and test it manually on Windows.
+2. Run `npm run promote-core-stable -- --version <version> --url <https-url> [--url <mirror>]`.
+3. The script downloads every exact artifact byte stream and calculates its SHA-256. It rejects HTTP and writes the manifest atomically.
+4. Review the `stable.json` diff, including every URL, version, and checksum.
+5. Open a separate pull request containing the manifest promotion. The script deliberately does not commit, push, merge, or publish.
+6. Once merged to `main`, clients receive the approved version without a new application release. Builds retain that manifest as their last-known-good offline fallback.
+
+The initial placeholder manifest intentionally contains no release. The execution environment used to add the channel could not reach GitHub, so no unverifiable production version or checksum was invented. A maintainer must run the promotion command in a networked environment before releasing this build.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zapret-ui",
-  "version": "26.7.5",
+  "version": "26.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zapret-ui",
-      "version": "26.7.5",
+      "version": "26.7.6",
       "devDependencies": {
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/vite": "^4.3.3",
@@ -722,13 +722,13 @@
       "cpu": [
         "x64"
       ],
+      "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
         "node": ">= 20"
-      },
-      "optional": true
+      }
     },
     "node_modules/@tailwindcss/vite": {
       "version": "4.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "zapret-ui",
       "version": "26.7.5",
-      "dependencies": {
-        "@tailwindcss/oxide-win32-x64-msvc": "^4.3.3"
-      },
       "devDependencies": {
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/vite": "^4.3.3",
@@ -18,6 +15,9 @@
         "postcss": "^8.5.23",
         "tailwindcss": "^4.3.3",
         "vite": "^8.1.5"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-win32-x64-msvc": "^4.3.3"
       }
     },
     "node_modules/@emnapi/core": {
@@ -727,7 +727,8 @@
       ],
       "engines": {
         "node": ">= 20"
-      }
+      },
+      "optional": true
     },
     "node_modules/@tailwindcss/vite": {
       "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "check-versions": "node scripts/check-versions.mjs",
-    "set-version": "node scripts/set-version.mjs"
+    "set-version": "node scripts/set-version.mjs",
+    "promote-core-stable": "node scripts/promote-core-stable.mjs"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.11",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tailwindcss": "^4.3.3",
     "vite": "^8.1.5"
   },
-  "dependencies": {
+  "optionalDependencies": {
     "@tailwindcss/oxide-win32-x64-msvc": "^4.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zapret-ui",
   "private": true,
-  "version": "26.7.5",
+  "version": "26.7.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/promote-core-stable.mjs
+++ b/scripts/promote-core-stable.mjs
@@ -1,0 +1,33 @@
+import { createHash } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { rename, rm } from 'node:fs/promises';
+import { Readable, Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import path from 'node:path';
+
+const args = process.argv.slice(2);
+let version;
+const urls = [];
+for (let i = 0; i < args.length; i += 2) {
+  if (args[i] === '--version') version = args[i + 1];
+  else if (args[i] === '--url') urls.push(args[i + 1]);
+  else throw new Error(`Unknown argument: ${args[i]}`);
+}
+if (!version?.trim() || urls.length === 0) throw new Error('Usage: --version <version> --url <https-url> [--url <https-url>]');
+for (const value of urls) if (new URL(value).protocol !== 'https:') throw new Error(`Only HTTPS artifacts are allowed: ${value}`);
+
+const artifacts = [];
+for (const url of urls) {
+  const response = await fetch(url, { redirect: 'follow' });
+  if (!response.ok || !response.body) throw new Error(`Download failed (${response.status}): ${url}`);
+  const hash = createHash('sha256');
+  await pipeline(Readable.fromWeb(response.body), new Transform({ transform(chunk, _encoding, callback) { hash.update(chunk); callback(); } }));
+  artifacts.push({ url, checksum: { algorithm: 'sha256', value: hash.digest('hex') } });
+}
+const target = path.resolve('core-channel/stable.json');
+const temporary = `${target}.tmp-${process.pid}`;
+try {
+  await pipeline(Readable.from(`${JSON.stringify({ schemaVersion: 1, channel: 'stable', provider: 'flowseal', version, artifacts }, null, 2)}\n`), createWriteStream(temporary, { flags: 'wx' }));
+  await rename(temporary, target);
+} finally { await rm(temporary, { force: true }); }
+console.log(`Promoted Flowseal ${version} with ${artifacts.length} verified artifact(s). Review the diff before committing.`);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4568,7 +4568,18 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2331,12 +2331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
-
-[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5880,7 +5874,6 @@ version = "26.7.5"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
- "md5",
  "reqwest",
  "rfd",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4576,6 +4576,7 @@ dependencies = [
 name = "tokio-macros"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5882,7 +5882,7 @@ dependencies = [
 
 [[package]]
 name = "zapret-ui"
-version = "26.7.5"
+version = "26.7.6"
 dependencies = [
  "base64 0.22.1",
  "futures-util",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,9 @@ zip = { version = "8", default-features = false, features = ["deflate", "deflate
 rfd = "0.15"
 tokio = { version = "1", features = ["net", "time"] }
 
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
+
 [[bin]]
 name = "zapret-ui"
 path = "src/main.rs"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zapret-ui"
-version = "26.7.5"
+version = "26.7.6"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,6 @@ sha2 = "0.11"
 base64 = "0.22"
 zip = { version = "8", default-features = false, features = ["deflate", "deflate-flate2", "bzip2"] }
 rfd = "0.15"
-md5 = "0.7"
 tokio = { version = "1", features = ["net", "time"] }
 
 [[bin]]

--- a/src-tauri/src/core/channel.rs
+++ b/src-tauri/src/core/channel.rs
@@ -114,7 +114,7 @@ where
         if body.len().saturating_add(chunk.len()) > MAX_MANIFEST_BYTES {
             return Err("channel response is too large".into());
         }
-        body.extend_from_slice(&chunk);
+        body.extend_from_slice(chunk);
     }
     Ok(body)
 }

--- a/src-tauri/src/core/channel.rs
+++ b/src-tauri/src/core/channel.rs
@@ -233,7 +233,7 @@ mod tests {
             "1.2.3"
         );
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn streaming_limit_stops_oversized_body() {
         let chunks = futures_util::stream::iter([
             Ok::<_, String>(vec![0; MAX_MANIFEST_BYTES]),

--- a/src-tauri/src/core/channel.rs
+++ b/src-tauri/src/core/channel.rs
@@ -1,0 +1,202 @@
+use reqwest::header::{CACHE_CONTROL, USER_AGENT};
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+
+const PRODUCTION_URL: &str =
+    "https://raw.githubusercontent.com/larrriiin/zapret-ui/main/core-channel/stable.json";
+const MAX_MANIFEST_BYTES: usize = 256 * 1024;
+const EMBEDDED: &str = include_str!("../../../core-channel/stable.json");
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct StableManifest {
+    pub schema_version: u32,
+    pub channel: String,
+    pub provider: String,
+    pub version: String,
+    pub artifacts: Vec<Artifact>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Artifact {
+    pub url: String,
+    pub checksum: ArtifactChecksum,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactChecksum {
+    pub algorithm: String,
+    pub value: String,
+}
+
+impl StableManifest {
+    pub fn parse_and_validate(bytes: &[u8], provider: &str) -> Result<Self, String> {
+        if bytes.len() > MAX_MANIFEST_BYTES {
+            return Err("channel manifest exceeds 256 KiB".into());
+        }
+        let value: Self = serde_json::from_slice(bytes)
+            .map_err(|_| "channel manifest is not valid schema v1 JSON".to_string())?;
+        if value.schema_version != 1 {
+            return Err(format!(
+                "unsupported channel schema {}",
+                value.schema_version
+            ));
+        }
+        if value.channel != "stable" {
+            return Err("channel must be stable".into());
+        }
+        if value.provider != provider {
+            return Err("channel provider does not match the installed provider".into());
+        }
+        if value.version.trim().is_empty() {
+            return Err("channel version is empty".into());
+        }
+        if value.artifacts.is_empty() {
+            return Err("stable channel contains no artifacts".into());
+        }
+        for artifact in &value.artifacts {
+            let url = reqwest::Url::parse(&artifact.url)
+                .map_err(|_| "artifact URL is invalid".to_string())?;
+            if url.scheme() != "https" {
+                return Err("stable artifacts must use HTTPS".into());
+            }
+            if artifact.checksum.algorithm != "sha256" {
+                return Err("stable artifacts require SHA-256".into());
+            }
+            let digest = &artifact.checksum.value;
+            if digest.len() != 64 || !digest.bytes().all(|b| b.is_ascii_hexdigit()) {
+                return Err("SHA-256 must contain exactly 64 hexadecimal characters".into());
+            }
+            if digest.bytes().any(|b| b.is_ascii_uppercase()) {
+                return Err("SHA-256 must be lowercase".into());
+            }
+        }
+        Ok(value)
+    }
+}
+
+fn channel_url() -> String {
+    #[cfg(debug_assertions)]
+    if let Ok(value) = std::env::var("ZAPRET_CORE_CHANNEL_URL") {
+        return value;
+    }
+    PRODUCTION_URL.to_string()
+}
+
+pub async fn resolve_stable(
+    client: &reqwest::Client,
+    provider: &str,
+    user_agent: &str,
+) -> Result<StableManifest, String> {
+    let remote = async {
+        let response = client
+            .get(channel_url())
+            .header(CACHE_CONTROL, "no-cache")
+            .header(USER_AGENT, user_agent)
+            .send()
+            .await
+            .map_err(|_| "channel request failed")?;
+        if !response.status().is_success() {
+            return Err("channel returned an HTTP error");
+        }
+        if response
+            .content_length()
+            .is_some_and(|n| n > MAX_MANIFEST_BYTES as u64)
+        {
+            return Err("channel response is too large");
+        }
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|_| "channel response could not be read")?;
+        StableManifest::parse_and_validate(&bytes, provider)
+            .map_err(|_| "remote channel validation failed")
+    }
+    .await;
+    match remote {
+        Ok(value) => Ok(value),
+        Err(reason) => {
+            eprintln!("Stable core channel fallback: {reason}");
+            StableManifest::parse_and_validate(EMBEDDED.as_bytes(), provider)
+                .map_err(|_| "Stable core channel is temporarily unavailable".to_string())
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CoreUpdateStatus {
+    NotInstalled,
+    UpdateAvailable,
+    UpToDate,
+    Ahead,
+    Unknown,
+}
+
+pub fn compare_versions(local: &str, stable: &str) -> CoreUpdateStatus {
+    fn parse(s: &str) -> Option<Vec<u64>> {
+        let s = s.trim().strip_prefix('v').unwrap_or(s.trim());
+        let parts: Option<Vec<_>> = s.split('.').map(|p| p.parse().ok()).collect();
+        parts.filter(|p| p.len() >= 2 && p.len() <= 4)
+    }
+    match (parse(local), parse(stable)) {
+        (Some(a), Some(b)) => match a.cmp(&b) {
+            Ordering::Less => CoreUpdateStatus::UpdateAvailable,
+            Ordering::Equal => CoreUpdateStatus::UpToDate,
+            Ordering::Greater => CoreUpdateStatus::Ahead,
+        },
+        _ => CoreUpdateStatus::Unknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn json(overrides: &str) -> Vec<u8> {
+        format!(r#"{{"schemaVersion":1,"channel":"stable","provider":"flowseal","version":"1.2.3","artifacts":[{{"url":"https://example.invalid/a.zip","checksum":{{"algorithm":"sha256","value":"{}"}}}}]{} }}"#, "a".repeat(64), overrides).into_bytes()
+    }
+    #[test]
+    fn valid_v1() {
+        StableManifest::parse_and_validate(&json(""), "flowseal").unwrap();
+    }
+    #[test]
+    fn comparisons() {
+        assert_eq!(
+            compare_versions("1.2.2", "1.2.3"),
+            CoreUpdateStatus::UpdateAvailable
+        );
+        assert_eq!(
+            compare_versions("1.2.3", "1.2.3"),
+            CoreUpdateStatus::UpToDate
+        );
+        assert_eq!(compare_versions("1.3.0", "1.2.3"), CoreUpdateStatus::Ahead);
+        assert_eq!(compare_versions("Err", "1.2.3"), CoreUpdateStatus::Unknown);
+    }
+    #[test]
+    fn rejects_invalid_fields() {
+        for (from, to) in [
+            ("\"schemaVersion\":1", "\"schemaVersion\":2"),
+            ("\"channel\":\"stable\"", "\"channel\":\"beta\""),
+            ("\"provider\":\"flowseal\"", "\"provider\":\"other\""),
+            ("\"version\":\"1.2.3\"", "\"version\":\"\""),
+            ("https://example.invalid", "http://example.invalid"),
+            ("\"algorithm\":\"sha256\"", "\"algorithm\":\"md5\""),
+        ] {
+            let s = String::from_utf8(json("")).unwrap().replace(from, to);
+            assert!(StableManifest::parse_and_validate(s.as_bytes(), "flowseal").is_err());
+        }
+        let empty=String::from_utf8(json("")).unwrap().replace(r#"[{"url"# , r#"_EMPTY_[{"url"#).replace(r#""artifacts":_EMPTY_[{"url":"https://example.invalid/a.zip","checksum":{"algorithm":"sha256","value":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}]"#, r#""artifacts":[]"#);
+        assert!(StableManifest::parse_and_validate(empty.as_bytes(), "flowseal").is_err());
+        for digest in [
+            "abc",
+            "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
+        ] {
+            let s = String::from_utf8(json(""))
+                .unwrap()
+                .replace(&"a".repeat(64), digest);
+            assert!(StableManifest::parse_and_validate(s.as_bytes(), "flowseal").is_err());
+        }
+    }
+}

--- a/src-tauri/src/core/channel.rs
+++ b/src-tauri/src/core/channel.rs
@@ -1,38 +1,41 @@
+use futures_util::{Stream, StreamExt};
 use reqwest::header::{CACHE_CONTROL, USER_AGENT};
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
+use std::{cmp::Ordering, pin::Pin};
+
+use super::{Checksum, CoreArtifact, CoreRelease};
 
 const PRODUCTION_URL: &str =
     "https://raw.githubusercontent.com/larrriiin/zapret-ui/main/core-channel/stable.json";
 const MAX_MANIFEST_BYTES: usize = 256 * 1024;
 const EMBEDDED: &str = include_str!("../../../core-channel/stable.json");
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct StableManifest {
-    pub schema_version: u32,
-    pub channel: String,
-    pub provider: String,
-    pub version: String,
-    pub artifacts: Vec<Artifact>,
+struct StableManifest {
+    schema_version: u32,
+    channel: String,
+    provider: String,
+    version: String,
+    artifacts: Vec<ManifestArtifact>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub struct Artifact {
-    pub url: String,
-    pub checksum: ArtifactChecksum,
+struct ManifestArtifact {
+    url: String,
+    checksum: ManifestChecksum,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub struct ArtifactChecksum {
-    pub algorithm: String,
-    pub value: String,
+struct ManifestChecksum {
+    algorithm: String,
+    value: String,
 }
 
 impl StableManifest {
-    pub fn parse_and_validate(bytes: &[u8], provider: &str) -> Result<Self, String> {
+    fn parse_and_validate(bytes: &[u8], provider: &str) -> Result<CoreRelease, String> {
         if bytes.len() > MAX_MANIFEST_BYTES {
             return Err("channel manifest exceeds 256 KiB".into());
         }
@@ -56,24 +59,37 @@ impl StableManifest {
         if value.artifacts.is_empty() {
             return Err("stable channel contains no artifacts".into());
         }
-        for artifact in &value.artifacts {
-            let url = reqwest::Url::parse(&artifact.url)
-                .map_err(|_| "artifact URL is invalid".to_string())?;
-            if url.scheme() != "https" {
-                return Err("stable artifacts must use HTTPS".into());
-            }
-            if artifact.checksum.algorithm != "sha256" {
-                return Err("stable artifacts require SHA-256".into());
-            }
-            let digest = &artifact.checksum.value;
-            if digest.len() != 64 || !digest.bytes().all(|b| b.is_ascii_hexdigit()) {
-                return Err("SHA-256 must contain exactly 64 hexadecimal characters".into());
-            }
-            if digest.bytes().any(|b| b.is_ascii_uppercase()) {
-                return Err("SHA-256 must be lowercase".into());
-            }
-        }
-        Ok(value)
+        let artifacts = value
+            .artifacts
+            .into_iter()
+            .map(|artifact| {
+                let url = reqwest::Url::parse(&artifact.url)
+                    .map_err(|_| "artifact URL is invalid".to_string())?;
+                if url.scheme() != "https" {
+                    return Err("stable artifacts must use HTTPS".into());
+                }
+                if artifact.checksum.algorithm != "sha256" {
+                    return Err("stable artifacts require SHA-256".into());
+                }
+                let digest = artifact.checksum.value;
+                if digest.len() != 64 || !digest.bytes().all(|b| b.is_ascii_hexdigit()) {
+                    return Err("SHA-256 must contain exactly 64 hexadecimal characters".into());
+                }
+                if digest.bytes().any(|b| b.is_ascii_uppercase()) {
+                    return Err("SHA-256 must be lowercase".into());
+                }
+                Ok(CoreArtifact {
+                    url: artifact.url,
+                    checksum: Checksum::Sha256(digest),
+                })
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        Ok(CoreRelease {
+            provider: value.provider,
+            channel: value.channel,
+            version: value.version,
+            artifacts,
+        })
     }
 }
 
@@ -85,11 +101,44 @@ fn channel_url() -> String {
     PRODUCTION_URL.to_string()
 }
 
+async fn collect_limited<S, B, E>(mut stream: Pin<Box<S>>) -> Result<Vec<u8>, String>
+where
+    S: Stream<Item = Result<B, E>> + ?Sized,
+    B: AsRef<[u8]>,
+    E: std::fmt::Display,
+{
+    let mut body = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("channel response could not be read: {e}"))?;
+        let chunk = chunk.as_ref();
+        if body.len().saturating_add(chunk.len()) > MAX_MANIFEST_BYTES {
+            return Err("channel response is too large".into());
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+fn resolve_bytes(
+    remote: Result<Vec<u8>, String>,
+    embedded: &[u8],
+    provider: &str,
+) -> Result<CoreRelease, String> {
+    match remote.and_then(|bytes| StableManifest::parse_and_validate(&bytes, provider)) {
+        Ok(release) => Ok(release),
+        Err(reason) => {
+            eprintln!("Stable core channel fallback: {reason}");
+            StableManifest::parse_and_validate(embedded, provider)
+                .map_err(|_| "Stable core channel is temporarily unavailable".to_string())
+        }
+    }
+}
+
 pub async fn resolve_stable(
     client: &reqwest::Client,
     provider: &str,
     user_agent: &str,
-) -> Result<StableManifest, String> {
+) -> Result<CoreRelease, String> {
     let remote = async {
         let response = client
             .get(channel_url())
@@ -97,32 +146,20 @@ pub async fn resolve_stable(
             .header(USER_AGENT, user_agent)
             .send()
             .await
-            .map_err(|_| "channel request failed")?;
+            .map_err(|_| "channel request failed".to_string())?;
         if !response.status().is_success() {
-            return Err("channel returned an HTTP error");
+            return Err("channel returned an HTTP error".into());
         }
         if response
             .content_length()
             .is_some_and(|n| n > MAX_MANIFEST_BYTES as u64)
         {
-            return Err("channel response is too large");
+            return Err("channel response is too large".into());
         }
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|_| "channel response could not be read")?;
-        StableManifest::parse_and_validate(&bytes, provider)
-            .map_err(|_| "remote channel validation failed")
+        collect_limited(Box::pin(response.bytes_stream())).await
     }
     .await;
-    match remote {
-        Ok(value) => Ok(value),
-        Err(reason) => {
-            eprintln!("Stable core channel fallback: {reason}");
-            StableManifest::parse_and_validate(EMBEDDED.as_bytes(), provider)
-                .map_err(|_| "Stable core channel is temporarily unavailable".to_string())
-        }
-    }
+    resolve_bytes(remote, EMBEDDED.as_bytes(), provider)
 }
 
 #[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
@@ -138,8 +175,18 @@ pub enum CoreUpdateStatus {
 pub fn compare_versions(local: &str, stable: &str) -> CoreUpdateStatus {
     fn parse(s: &str) -> Option<Vec<u64>> {
         let s = s.trim().strip_prefix('v').unwrap_or(s.trim());
-        let parts: Option<Vec<_>> = s.split('.').map(|p| p.parse().ok()).collect();
-        parts.filter(|p| p.len() >= 2 && p.len() <= 4)
+        let mut parts: Vec<u64> = s
+            .split('.')
+            .map(str::parse)
+            .collect::<Result<_, _>>()
+            .ok()?;
+        if !(2..=4).contains(&parts.len()) {
+            return None;
+        }
+        while parts.last() == Some(&0) {
+            parts.pop();
+        }
+        Some(parts)
     }
     match (parse(local), parse(stable)) {
         (Some(a), Some(b)) => match a.cmp(&b) {
@@ -154,25 +201,48 @@ pub fn compare_versions(local: &str, stable: &str) -> CoreUpdateStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
-    fn json(overrides: &str) -> Vec<u8> {
-        format!(r#"{{"schemaVersion":1,"channel":"stable","provider":"flowseal","version":"1.2.3","artifacts":[{{"url":"https://example.invalid/a.zip","checksum":{{"algorithm":"sha256","value":"{}"}}}}]{} }}"#, "a".repeat(64), overrides).into_bytes()
+    fn valid() -> Vec<u8> {
+        format!(r#"{{"schemaVersion":1,"channel":"stable","provider":"flowseal","version":"1.2.3","artifacts":[{{"url":"https://example.invalid/a.zip","checksum":{{"algorithm":"sha256","value":"{}"}}}}]}}"#, "a".repeat(64)).into_bytes()
     }
     #[test]
     fn valid_v1() {
-        StableManifest::parse_and_validate(&json(""), "flowseal").unwrap();
+        StableManifest::parse_and_validate(&valid(), "flowseal").unwrap();
     }
     #[test]
-    fn comparisons() {
+    fn comparisons_normalize_zero_components() {
         assert_eq!(
             compare_versions("1.2.2", "1.2.3"),
             CoreUpdateStatus::UpdateAvailable
         );
-        assert_eq!(
-            compare_versions("1.2.3", "1.2.3"),
-            CoreUpdateStatus::UpToDate
-        );
+        assert_eq!(compare_versions("1.2", "1.2.0"), CoreUpdateStatus::UpToDate);
         assert_eq!(compare_versions("1.3.0", "1.2.3"), CoreUpdateStatus::Ahead);
         assert_eq!(compare_versions("Err", "1.2.3"), CoreUpdateStatus::Unknown);
+    }
+    #[test]
+    fn remote_error_and_invalid_remote_use_embedded() {
+        assert_eq!(
+            resolve_bytes(Err("offline".into()), &valid(), "flowseal")
+                .unwrap()
+                .version,
+            "1.2.3"
+        );
+        assert_eq!(
+            resolve_bytes(Ok(b"not json".to_vec()), &valid(), "flowseal")
+                .unwrap()
+                .version,
+            "1.2.3"
+        );
+    }
+    #[tokio::test]
+    async fn streaming_limit_stops_oversized_body() {
+        let chunks = futures_util::stream::iter([
+            Ok::<_, String>(vec![0; MAX_MANIFEST_BYTES]),
+            Ok(vec![b'x']),
+        ]);
+        assert!(collect_limited(Box::pin(chunks))
+            .await
+            .unwrap_err()
+            .contains("too large"));
     }
     #[test]
     fn rejects_invalid_fields() {
@@ -184,19 +254,21 @@ mod tests {
             ("https://example.invalid", "http://example.invalid"),
             ("\"algorithm\":\"sha256\"", "\"algorithm\":\"md5\""),
         ] {
-            let s = String::from_utf8(json("")).unwrap().replace(from, to);
-            assert!(StableManifest::parse_and_validate(s.as_bytes(), "flowseal").is_err());
+            let body = String::from_utf8(valid()).unwrap().replace(from, to);
+            assert!(StableManifest::parse_and_validate(body.as_bytes(), "flowseal").is_err());
         }
-        let empty=String::from_utf8(json("")).unwrap().replace(r#"[{"url"# , r#"_EMPTY_[{"url"#).replace(r#""artifacts":_EMPTY_[{"url":"https://example.invalid/a.zip","checksum":{"algorithm":"sha256","value":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}]"#, r#""artifacts":[]"#);
-        assert!(StableManifest::parse_and_validate(empty.as_bytes(), "flowseal").is_err());
+        let empty = serde_json::json!({"schemaVersion":1,"channel":"stable","provider":"flowseal","version":"1.2.3","artifacts":[]});
+        assert!(
+            StableManifest::parse_and_validate(empty.to_string().as_bytes(), "flowseal").is_err()
+        );
         for digest in [
             "abc",
             "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
         ] {
-            let s = String::from_utf8(json(""))
+            let body = String::from_utf8(valid())
                 .unwrap()
                 .replace(&"a".repeat(64), digest);
-            assert!(StableManifest::parse_and_validate(s.as_bytes(), "flowseal").is_err());
+            assert!(StableManifest::parse_and_validate(body.as_bytes(), "flowseal").is_err());
         }
     }
 }

--- a/src-tauri/src/core/installation.rs
+++ b/src-tauri/src/core/installation.rs
@@ -1,0 +1,882 @@
+use serde::{Deserialize, Serialize};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use super::{Checksum, CoreProvider};
+
+pub const MANIFEST_NAME: &str = ".zapret-ui-core.json";
+const SCHEMA_VERSION: u32 = 1;
+const STAGING_PREFIX: &str = ".binaries-staging-";
+const SWAP_NAME: &str = ".binaries-rollback-swap";
+const RESTORE_SWAP_NAME: &str = ".binaries-rollback-restore-swap";
+const PREVIOUS_BACKUP_NAME: &str = ".binaries-previous-backup";
+const USER_FILES: [&str; 3] = [
+    "list-general-user.txt",
+    "list-exclude-user.txt",
+    "ipset-exclude-user.txt",
+];
+const ACTIVE_FAKE_FILES: [&str; 2] = ["ACTIVE_DISCORD_UDP.bin", "ACTIVE_GAME_UDP.bin"];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CoreManifest {
+    pub schema_version: u32,
+    pub provider: String,
+    pub version: String,
+    pub source_url: Option<String>,
+    pub checksum: Option<Checksum>,
+    pub strategy_count: usize,
+    #[serde(default)]
+    pub imported_legacy: bool,
+}
+
+impl CoreManifest {
+    pub fn new(
+        provider: String,
+        version: String,
+        source_url: Option<String>,
+        checksum: Option<Checksum>,
+        strategy_count: usize,
+        imported_legacy: bool,
+    ) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            provider,
+            version,
+            source_url,
+            checksum,
+            strategy_count,
+            imported_legacy,
+        }
+    }
+
+    pub fn read(root: &Path) -> Result<Self, String> {
+        let path = root.join(MANIFEST_NAME);
+        let data = fs::read(&path).map_err(|e| {
+            format!(
+                "Core manifest is missing or unreadable ({}): {e}",
+                path.display()
+            )
+        })?;
+        let value: Self = serde_json::from_slice(&data)
+            .map_err(|e| format!("Core manifest is corrupted: {e}"))?;
+        if value.schema_version != SCHEMA_VERSION {
+            return Err(format!(
+                "Unsupported core manifest schema version: {}",
+                value.schema_version
+            ));
+        }
+        Ok(value)
+    }
+
+    pub fn write_atomic(&self, root: &Path) -> Result<(), String> {
+        let path = root.join(MANIFEST_NAME);
+        let temporary = root.join(format!("{MANIFEST_NAME}.tmp-{}", std::process::id()));
+        let data = serde_json::to_vec_pretty(self)
+            .map_err(|e| format!("Cannot serialize core manifest: {e}"))?;
+        fs::write(&temporary, data)
+            .map_err(|e| format!("Cannot write temporary core manifest: {e}"))?;
+        fs::rename(&temporary, &path).map_err(|e| format!("Cannot activate core manifest: {e}"))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CoreInstallationState {
+    pub current_version: Option<String>,
+    pub previous_version: Option<String>,
+    pub rollback_available: bool,
+}
+
+pub struct CoreInstallation {
+    parent: PathBuf,
+    active: PathBuf,
+    previous: PathBuf,
+}
+
+impl CoreInstallation {
+    pub fn new(active: impl Into<PathBuf>) -> Result<Self, String> {
+        let requested = active.into();
+        let parent = requested
+            .parent()
+            .ok_or_else(|| "Core directory has no parent".to_string())?
+            .canonicalize()
+            .map_err(|e| format!("Cannot verify core parent directory: {e}"))?;
+        if requested.file_name().and_then(|n| n.to_str()) != Some("binaries") {
+            return Err("Active core directory must be named binaries".into());
+        }
+        let active = parent.join("binaries");
+        Ok(Self {
+            previous: parent.join("binaries.previous"),
+            parent,
+            active,
+        })
+    }
+
+    pub fn recover(&self) -> Result<(), String> {
+        fs::create_dir_all(&self.parent).map_err(|e| format!("Cannot prepare core parent: {e}"))?;
+        self.recover_interrupted_rollback_restore()?;
+        self.recover_interrupted_rollback()?;
+        self.recover_interrupted_activation()?;
+        if !self.active.exists() && self.previous.exists() {
+            self.assert_owned(&self.previous, "binaries.previous")?;
+            fs::rename(&self.previous, &self.active)
+                .map_err(|e| format!("Cannot recover previous core: {e}"))?;
+            eprintln!("Recovered binaries.previous after an interrupted core update");
+        }
+        if self.active.exists() {
+            for entry in fs::read_dir(&self.parent).map_err(|e| e.to_string())? {
+                let path = entry.map_err(|e| e.to_string())?.path();
+                if path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with(STAGING_PREFIX))
+                {
+                    self.remove_owned_staging(&path)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn prepare(&self, provider: &dyn CoreProvider) -> Result<(), String> {
+        self.recover()?;
+        if self.active.is_dir() && !self.active.join(MANIFEST_NAME).exists() {
+            let (version, count) = provider.validate_installation()?;
+            CoreManifest::new(
+                provider.provider_name().into(),
+                version,
+                None,
+                None,
+                count,
+                true,
+            )
+            .write_atomic(&self.active)?;
+        }
+        Ok(())
+    }
+
+    pub fn state(&self) -> CoreInstallationState {
+        let current_version = CoreManifest::read(&self.active).ok().map(|m| m.version);
+        let previous_version = CoreManifest::read(&self.previous).ok().map(|m| m.version);
+        CoreInstallationState {
+            rollback_available: previous_version.is_some(),
+            current_version,
+            previous_version,
+        }
+    }
+
+    pub fn create_staging(&self) -> Result<PathBuf, String> {
+        fs::create_dir_all(&self.parent).map_err(|e| e.to_string())?;
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| e.to_string())?
+            .as_nanos();
+        let path = self
+            .parent
+            .join(format!("{STAGING_PREFIX}{}-{stamp}", std::process::id()));
+        fs::create_dir(&path).map_err(|e| format!("Cannot create staging directory: {e}"))?;
+        Ok(path)
+    }
+
+    pub fn validate_and_manifest(
+        &self,
+        root: &Path,
+        expected_version: &str,
+        source_url: Option<String>,
+        checksum: Option<Checksum>,
+        provider: &dyn CoreProvider,
+    ) -> Result<CoreManifest, String> {
+        self.assert_staging(root)?;
+        reject_symlinks(root)?;
+        let (actual, count) = provider.validate_installation()?;
+        if actual != expected_version {
+            return Err(format!(
+                "Core version mismatch: expected {expected_version}, found {actual}"
+            ));
+        }
+        let manifest = CoreManifest::new(
+            provider.provider_name().into(),
+            actual,
+            source_url,
+            checksum,
+            count,
+            false,
+        );
+        serde_json::to_vec(&manifest)
+            .map_err(|e| format!("Cannot serialize core manifest: {e}"))?;
+        manifest.write_atomic(root)?;
+        Ok(manifest)
+    }
+
+    pub fn preserve_user_files(&self, from: &Path, to: &Path) -> Result<(), String> {
+        let destination = to.join("lists");
+        fs::create_dir_all(&destination)
+            .map_err(|e| format!("Cannot create lists directory: {e}"))?;
+        for name in USER_FILES {
+            let source = from.join("lists").join(name);
+            if source.is_file() {
+                fs::copy(&source, destination.join(name))
+                    .map_err(|e| format!("Cannot preserve {name}: {e}"))?;
+            }
+        }
+        let destination_bin = to.join("bin");
+        for name in ACTIVE_FAKE_FILES {
+            let source = from.join("bin").join(name);
+            if source.is_file() {
+                fs::copy(&source, destination_bin.join(name))
+                    .map_err(|e| format!("Cannot preserve selected fake {name}: {e}"))?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn activate(
+        &self,
+        staging: &Path,
+        active_provider: &dyn CoreProvider,
+    ) -> Result<(), String> {
+        self.assert_staging(staging)?;
+        CoreManifest::read(staging)?;
+        if !self.active.is_dir() {
+            return Err("Active core is missing".into());
+        }
+        self.preserve_user_files(&self.active, staging)?;
+        let previous_backup = self.parent.join(PREVIOUS_BACKUP_NAME);
+        if previous_backup.exists() {
+            return Err("Previous-core backup already exists; recovery is required".into());
+        }
+        if self.previous.exists() {
+            self.assert_owned(&self.previous, "binaries.previous")?;
+            fs::rename(&self.previous, &previous_backup)
+                .map_err(|e| format!("Cannot preserve old previous core: {e}"))?;
+        }
+        if let Err(error) = fs::rename(&self.active, &self.previous) {
+            self.restore_previous_backup(&previous_backup)?;
+            return Err(format!("Cannot save active core: {error}"));
+        }
+        if let Err(error) = fs::rename(staging, &self.active) {
+            self.restore_failed_activation(&previous_backup)
+                .map_err(|rollback| {
+                    format!(
+                        "Activation failed ({error}); automatic rollback also failed: {rollback}"
+                    )
+                })?;
+            return Err(format!(
+                "Activation failed ({error}); automatic rollback completed"
+            ));
+        }
+        if let Err(error) = active_provider.validate_installation() {
+            let failed = self
+                .parent
+                .join(format!("{STAGING_PREFIX}failed-{}", std::process::id()));
+            fs::rename(&self.active, &failed).map_err(|e| {
+                format!(
+                    "Post-activation validation failed ({error}); cannot quarantine new core: {e}"
+                )
+            })?;
+            fs::rename(&self.previous, &self.active).map_err(|e| {
+                format!(
+                    "Post-activation validation failed ({error}); automatic rollback failed: {e}"
+                )
+            })?;
+            self.restore_previous_backup(&previous_backup)?;
+            self.remove_owned_staging(&failed)?;
+            return Err(format!(
+                "Post-activation validation failed ({error}); automatic rollback completed"
+            ));
+        }
+        if previous_backup.exists() {
+            self.assert_owned(&previous_backup, PREVIOUS_BACKUP_NAME)?;
+            fs::remove_dir_all(&previous_backup)
+                .map_err(|e| format!("Cannot remove committed previous-core backup: {e}"))?;
+        }
+        Ok(())
+    }
+
+    pub fn rollback(
+        &self,
+        active_provider: &dyn CoreProvider,
+        previous_provider: &dyn CoreProvider,
+    ) -> Result<CoreInstallationState, String> {
+        self.rollback_with_post_validation(previous_provider, || {
+            active_provider.validate_installation().map(|_| ())
+        })
+    }
+
+    fn rollback_with_post_validation(
+        &self,
+        previous_provider: &dyn CoreProvider,
+        post_validate: impl FnOnce() -> Result<(), String>,
+    ) -> Result<CoreInstallationState, String> {
+        if !self.previous.is_dir() {
+            return Err("Rollback is unavailable: previous core is missing".into());
+        }
+        CoreManifest::read(&self.previous)?;
+        previous_provider.validate_installation()?;
+        self.preserve_user_files(&self.active, &self.previous)?;
+        let swap = self.parent.join(SWAP_NAME);
+        if swap.exists() {
+            return Err("Rollback swap directory already exists; recovery is required".into());
+        }
+        fs::rename(&self.active, &swap).map_err(|e| format!("Cannot begin rollback: {e}"))?;
+        if let Err(error) = fs::rename(&self.previous, &self.active) {
+            fs::rename(&swap, &self.active)
+                .map_err(|e| format!("Rollback failed ({error}); restoration failed: {e}"))?;
+            return Err(format!("Rollback failed ({error}); active core restored"));
+        }
+        if let Err(error) = fs::rename(&swap, &self.previous) {
+            fs::rename(&self.active, &self.previous).map_err(|e| {
+                format!("Rollback swap failed ({error}); cannot move selected core back: {e}")
+            })?;
+            fs::rename(&swap, &self.active).map_err(|e| {
+                format!("Rollback swap failed ({error}); cannot restore active core: {e}")
+            })?;
+            return Err(format!(
+                "Rollback swap failed: {error}; active core restored"
+            ));
+        }
+        if let Err(validation_error) = post_validate() {
+            self.reverse_completed_rollback().map_err(|restore_error| {
+                format!(
+                    "Rollback post-validation failed ({validation_error}); restoration failed: {restore_error}"
+                )
+            })?;
+            return Err(format!(
+                "Rollback post-validation failed ({validation_error}); original installation restored"
+            ));
+        }
+        Ok(self.state())
+    }
+
+    fn reverse_completed_rollback(&self) -> Result<(), String> {
+        let swap = self.parent.join(RESTORE_SWAP_NAME);
+        if swap.exists() {
+            return Err("Rollback restore swap unexpectedly exists during restoration".into());
+        }
+        fs::rename(&self.active, &swap)
+            .map_err(|e| format!("Cannot move failed rollback core aside: {e}"))?;
+        if let Err(error) = fs::rename(&self.previous, &self.active) {
+            return Err(format!(
+                "Cannot restore original active core ({error}); recovery marker was retained"
+            ));
+        }
+        if let Err(error) = fs::rename(&swap, &self.previous) {
+            return Err(format!(
+                "Cannot restore original previous core ({error}); original active core is working and recovery marker was retained"
+            ));
+        }
+        Ok(())
+    }
+
+    fn recover_interrupted_rollback_restore(&self) -> Result<(), String> {
+        let restore_swap = self.parent.join(RESTORE_SWAP_NAME);
+        if !restore_swap.exists() {
+            return Ok(());
+        }
+        self.assert_owned(&restore_swap, RESTORE_SWAP_NAME)?;
+        match (self.active.exists(), self.previous.exists()) {
+            (false, true) => {
+                fs::rename(&self.previous, &self.active).map_err(|e| {
+                    format!("Cannot restore original active core during recovery: {e}")
+                })?;
+                fs::rename(&restore_swap, &self.previous).map_err(|e| {
+                    format!(
+                        "Original active core was recovered, but previous core restoration must be retried: {e}"
+                    )
+                })?;
+            }
+            (true, false) => {
+                fs::rename(&restore_swap, &self.previous).map_err(|e| {
+                    format!("Cannot finish previous core restoration during recovery: {e}")
+                })?;
+            }
+            (true, true) => {
+                return Err(
+                    "Ambiguous rollback restoration: active, previous, and restore swap all exist"
+                        .to_string(),
+                );
+            }
+            (false, false) => {
+                return Err(
+                    "Cannot recover rollback restoration: only the invalid restore swap remains"
+                        .to_string(),
+                );
+            }
+        }
+        eprintln!("Recovered interrupted rollback restoration");
+        Ok(())
+    }
+
+    fn recover_interrupted_rollback(&self) -> Result<(), String> {
+        let swap = self.parent.join(SWAP_NAME);
+        if !swap.exists() {
+            return Ok(());
+        }
+        self.assert_owned(&swap, SWAP_NAME)?;
+        match (self.active.exists(), self.previous.exists()) {
+            (false, true) => {
+                fs::rename(&swap, &self.active)
+                    .map_err(|e| format!("Cannot restore active core from rollback swap: {e}"))?;
+            }
+            (true, false) => {
+                fs::rename(&swap, &self.previous)
+                    .map_err(|e| format!("Cannot complete interrupted rollback from swap: {e}"))?;
+            }
+            (false, false) => {
+                fs::rename(&swap, &self.active)
+                    .map_err(|e| format!("Cannot recover sole core from rollback swap: {e}"))?;
+            }
+            (true, true) => {
+                return Err(
+                    "Ambiguous interrupted rollback: active, previous, and swap all exist"
+                        .to_string(),
+                );
+            }
+        }
+        eprintln!("Recovered interrupted core rollback");
+        Ok(())
+    }
+
+    fn recover_interrupted_activation(&self) -> Result<(), String> {
+        let backup = self.parent.join(PREVIOUS_BACKUP_NAME);
+        if !backup.exists() {
+            return Ok(());
+        }
+        self.assert_owned(&backup, PREVIOUS_BACKUP_NAME)?;
+        match (self.active.exists(), self.previous.exists()) {
+            (true, false) => self.restore_previous_backup(&backup)?,
+            (false, true) => self.restore_failed_activation(&backup)?,
+            (true, true) => {
+                fs::remove_dir_all(&backup)
+                    .map_err(|e| format!("Cannot clean committed previous-core backup: {e}"))?;
+            }
+            (false, false) => {
+                fs::rename(&backup, &self.active)
+                    .map_err(|e| format!("Cannot recover sole previous-core backup: {e}"))?;
+            }
+        }
+        eprintln!("Recovered interrupted core activation");
+        Ok(())
+    }
+
+    fn restore_failed_activation(&self, previous_backup: &Path) -> Result<(), String> {
+        fs::rename(&self.previous, &self.active)
+            .map_err(|e| format!("Cannot restore active core: {e}"))?;
+        self.restore_previous_backup(previous_backup)
+    }
+
+    fn restore_previous_backup(&self, previous_backup: &Path) -> Result<(), String> {
+        if previous_backup.exists() {
+            fs::rename(previous_backup, &self.previous)
+                .map_err(|e| format!("Cannot restore old previous core: {e}"))?;
+        }
+        Ok(())
+    }
+
+    pub fn remove_owned_staging(&self, path: &Path) -> Result<(), String> {
+        self.assert_staging(path)?;
+        if path.exists() {
+            reject_symlinks(path)?;
+            fs::remove_dir_all(path).map_err(|e| format!("Cannot remove staging: {e}"))?;
+        }
+        Ok(())
+    }
+
+    fn assert_staging(&self, path: &Path) -> Result<(), String> {
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+        if path.parent() != Some(self.parent.as_path()) || !name.starts_with(STAGING_PREFIX) {
+            return Err(format!("Refusing unsafe staging path: {}", path.display()));
+        }
+        Ok(())
+    }
+    fn assert_owned(&self, path: &Path, expected: &str) -> Result<(), String> {
+        if path.parent() != Some(self.parent.as_path())
+            || path.file_name().and_then(|n| n.to_str()) != Some(expected)
+        {
+            return Err(format!("Refusing unsafe core path: {}", path.display()));
+        }
+        reject_symlinks(path)
+    }
+}
+
+fn reject_symlinks(root: &Path) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(root)
+        .map_err(|e| format!("Cannot inspect {}: {e}", root.display()))?;
+    if metadata.file_type().is_symlink() {
+        return Err(format!(
+            "Symlink/junction is not allowed: {}",
+            root.display()
+        ));
+    }
+    if metadata.is_dir() {
+        for entry in fs::read_dir(root).map_err(|e| e.to_string())? {
+            reject_symlinks(&entry.map_err(|e| e.to_string())?.path())?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::CoreManager;
+
+    fn provider(root: &Path) -> &dyn CoreProvider {
+        // Managers are intentionally leaked only in tests so returned provider references
+        // remain valid for the duration of each isolated filesystem scenario.
+        Box::leak(Box::new(CoreManager::new(root))).provider()
+    }
+
+    struct Temp(PathBuf);
+    impl Temp {
+        fn new() -> Self {
+            let stamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "zapret-install-test-{}-{stamp}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+    }
+    impl Drop for Temp {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn fixture(root: &Path, version: &str) {
+        fs::create_dir_all(root.join("bin")).unwrap();
+        fs::create_dir_all(root.join("lists")).unwrap();
+        fs::create_dir_all(root.join("utils")).unwrap();
+        fs::write(
+            root.join("service.bat"),
+            format!("set local_version={version}\n"),
+        )
+        .unwrap();
+        fs::write(root.join("general.bat"), "\"%BIN%winws.exe\" --wf-tcp=80\n").unwrap();
+        for file in ["winws.exe", "WinDivert.dll", "WinDivert64.sys"] {
+            fs::write(root.join("bin").join(file), b"fixture").unwrap();
+        }
+        fs::write(root.join("utils/test zapret.ps1"), b"fixture").unwrap();
+    }
+
+    fn manifest(version: &str) -> CoreManifest {
+        CoreManifest::new(
+            "fixture-provider".into(),
+            version.into(),
+            None,
+            None,
+            1,
+            false,
+        )
+    }
+
+    #[test]
+    fn manifest_round_trip_and_unknown_schema_rejected() {
+        let temp = Temp::new();
+        manifest("1.2.3").write_atomic(&temp.0).unwrap();
+        assert_eq!(CoreManifest::read(&temp.0).unwrap(), manifest("1.2.3"));
+        let mut invalid = manifest("1.2.3");
+        invalid.schema_version = 99;
+        fs::write(
+            temp.0.join(MANIFEST_NAME),
+            serde_json::to_vec(&invalid).unwrap(),
+        )
+        .unwrap();
+        assert!(CoreManifest::read(&temp.0)
+            .unwrap_err()
+            .contains("Unsupported"));
+    }
+
+    #[test]
+    fn imports_legacy_installation_without_moving_it() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        fixture(&active, "1.0.0");
+        let installation = CoreInstallation::new(&active).unwrap();
+        installation.prepare(provider(&active)).unwrap();
+        let imported = CoreManifest::read(&active).unwrap();
+        assert!(imported.imported_legacy);
+        assert_eq!(imported.version, "1.0.0");
+        assert!(!installation.state().rollback_available);
+    }
+
+    #[test]
+    fn validates_fixture_and_reports_missing_required_files() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        fs::create_dir(&active).unwrap();
+        let installation = CoreInstallation::new(&active).unwrap();
+        for missing in ["service.bat", "bin/winws.exe", "utils/test zapret.ps1"] {
+            let staging = installation.create_staging().unwrap();
+            fixture(&staging, "2.0.0");
+            fs::remove_file(staging.join(missing)).unwrap();
+            assert!(installation
+                .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+                .unwrap_err()
+                .contains("Missing required"));
+            installation.remove_owned_staging(&staging).unwrap();
+        }
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        installation
+            .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+            .unwrap();
+    }
+
+    #[test]
+    fn rejects_missing_bad_strategy_and_version_mismatch() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        fs::create_dir(&active).unwrap();
+        let installation = CoreInstallation::new(&active).unwrap();
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        fs::remove_file(staging.join("general.bat")).unwrap();
+        assert!(installation
+            .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+            .unwrap_err()
+            .contains("No Flowseal strategies"));
+        installation.remove_owned_staging(&staging).unwrap();
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        fs::write(staging.join("general.bat"), "invalid").unwrap();
+        assert!(installation
+            .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+            .unwrap_err()
+            .contains("cannot be parsed"));
+        installation.remove_owned_staging(&staging).unwrap();
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        assert!(installation
+            .validate_and_manifest(&staging, "3.0.0", None, None, provider(&staging))
+            .unwrap_err()
+            .contains("version mismatch"));
+    }
+
+    #[test]
+    fn activation_and_rollback_swap_versions_and_keep_current_lists() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        fixture(&active, "1.0.0");
+        manifest("1.0.0").write_atomic(&active).unwrap();
+        fs::write(active.join("lists/list-general-user.txt"), "current").unwrap();
+        let installation = CoreInstallation::new(&active).unwrap();
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        installation
+            .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+            .unwrap();
+        installation.activate(&staging, provider(&active)).unwrap();
+        assert_eq!(
+            installation.state().current_version.as_deref(),
+            Some("2.0.0")
+        );
+        fs::write(
+            active.join("lists/list-general-user.txt"),
+            "changed-after-update",
+        )
+        .unwrap();
+        let state = installation
+            .rollback(
+                provider(&active),
+                provider(&temp.0.join("binaries.previous")),
+            )
+            .unwrap();
+        assert_eq!(state.current_version.as_deref(), Some("1.0.0"));
+        assert_eq!(state.previous_version.as_deref(), Some("2.0.0"));
+        assert_eq!(
+            fs::read_to_string(active.join("lists/list-general-user.txt")).unwrap(),
+            "changed-after-update"
+        );
+    }
+
+    #[test]
+    fn rollback_unavailable_recovery_idempotent_and_removal_is_scoped() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let previous = temp.0.join("binaries.previous");
+        fixture(&previous, "1.0.0");
+        manifest("1.0.0").write_atomic(&previous).unwrap();
+        let installation = CoreInstallation::new(&active).unwrap();
+        installation.recover().unwrap();
+        installation.recover().unwrap();
+        assert!(active.is_dir());
+        assert!(installation
+            .rollback(
+                provider(&active),
+                provider(&temp.0.join("binaries.previous"))
+            )
+            .unwrap_err()
+            .contains("unavailable"));
+        let outside = temp.0.join("unrelated");
+        fs::create_dir(&outside).unwrap();
+        assert!(installation.remove_owned_staging(&outside).is_err());
+        assert!(outside.exists());
+    }
+
+    #[test]
+    fn recovers_every_interrupted_rollback_state_idempotently() {
+        for (active_exists, previous_exists) in [(false, true), (true, false), (false, false)] {
+            let temp = Temp::new();
+            let active = temp.0.join("binaries");
+            let previous = temp.0.join("binaries.previous");
+            let swap = temp.0.join(SWAP_NAME);
+            if active_exists {
+                fixture(&active, "2.0.0");
+                manifest("2.0.0").write_atomic(&active).unwrap();
+            }
+            if previous_exists {
+                fixture(&previous, "1.0.0");
+                manifest("1.0.0").write_atomic(&previous).unwrap();
+            }
+            fixture(&swap, "2.0.0");
+            manifest("2.0.0").write_atomic(&swap).unwrap();
+            let installation = CoreInstallation::new(&active).unwrap();
+            installation.recover().unwrap();
+            installation.recover().unwrap();
+            assert!(active.exists());
+            assert!(!swap.exists());
+            if active_exists && !previous_exists {
+                assert!(previous.exists());
+            }
+        }
+    }
+
+    #[test]
+    fn recovers_interrupted_activation_and_restores_old_previous() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let previous = temp.0.join("binaries.previous");
+        let backup = temp.0.join(PREVIOUS_BACKUP_NAME);
+        fixture(&previous, "2.0.0");
+        manifest("2.0.0").write_atomic(&previous).unwrap();
+        fixture(&backup, "0.9.0");
+        manifest("0.9.0").write_atomic(&backup).unwrap();
+        let installation = CoreInstallation::new(&active).unwrap();
+        installation.recover().unwrap();
+        installation.recover().unwrap();
+        assert_eq!(CoreManifest::read(&active).unwrap().version, "2.0.0");
+        assert_eq!(CoreManifest::read(&previous).unwrap().version, "0.9.0");
+        assert!(!backup.exists());
+    }
+
+    #[test]
+    fn successful_activation_replaces_previous_only_after_commit() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let previous = temp.0.join("binaries.previous");
+        fixture(&active, "1.0.0");
+        manifest("1.0.0").write_atomic(&active).unwrap();
+        fixture(&previous, "0.9.0");
+        manifest("0.9.0").write_atomic(&previous).unwrap();
+        let installation = CoreInstallation::new(&active).unwrap();
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        installation
+            .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+            .unwrap();
+        installation.activate(&staging, provider(&active)).unwrap();
+        assert_eq!(CoreManifest::read(&active).unwrap().version, "2.0.0");
+        assert_eq!(CoreManifest::read(&previous).unwrap().version, "1.0.0");
+        assert!(!temp.0.join(PREVIOUS_BACKUP_NAME).exists());
+    }
+
+    #[test]
+    fn failed_activation_restores_active_and_old_previous_and_cleans_candidate() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let previous = temp.0.join("binaries.previous");
+        fixture(&active, "1.0.0");
+        manifest("1.0.0").write_atomic(&active).unwrap();
+        fixture(&previous, "0.9.0");
+        manifest("0.9.0").write_atomic(&previous).unwrap();
+        let installation = CoreInstallation::new(&active).unwrap();
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        installation
+            .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+            .unwrap();
+        fs::remove_file(staging.join("service.bat")).unwrap();
+        assert!(installation
+            .activate(&staging, provider(&active))
+            .unwrap_err()
+            .contains("automatic rollback completed"));
+        assert_eq!(CoreManifest::read(&active).unwrap().version, "1.0.0");
+        assert_eq!(CoreManifest::read(&previous).unwrap().version, "0.9.0");
+        assert!(!staging.exists());
+        assert!(!temp.0.join(PREVIOUS_BACKUP_NAME).exists());
+    }
+
+    #[test]
+    fn rollback_post_validation_failure_restores_original_directories() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let previous = temp.0.join("binaries.previous");
+        fixture(&active, "2.0.0");
+        manifest("2.0.0").write_atomic(&active).unwrap();
+        fixture(&previous, "1.0.0");
+        manifest("1.0.0").write_atomic(&previous).unwrap();
+        let installation = CoreInstallation::new(&active).unwrap();
+        let error = installation
+            .rollback_with_post_validation(provider(&previous), || {
+                Err("simulated validation failure".to_string())
+            })
+            .unwrap_err();
+        assert!(error.contains("original installation restored"));
+        assert_eq!(CoreManifest::read(&active).unwrap().version, "2.0.0");
+        assert_eq!(CoreManifest::read(&previous).unwrap().version, "1.0.0");
+        assert!(!temp.0.join(SWAP_NAME).exists());
+    }
+
+    #[test]
+    fn recovers_rollback_restore_before_original_active_was_restored() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let previous = temp.0.join("binaries.previous");
+        let restore_swap = temp.0.join(RESTORE_SWAP_NAME);
+        fixture(&previous, "2.0.0");
+        manifest("2.0.0").write_atomic(&previous).unwrap();
+        fixture(&restore_swap, "1.0.0");
+        manifest("1.0.0").write_atomic(&restore_swap).unwrap();
+
+        let installation = CoreInstallation::new(&active).unwrap();
+        installation.recover().unwrap();
+        installation.recover().unwrap();
+
+        assert_eq!(CoreManifest::read(&active).unwrap().version, "2.0.0");
+        assert_eq!(CoreManifest::read(&previous).unwrap().version, "1.0.0");
+        assert!(!restore_swap.exists());
+    }
+
+    #[test]
+    fn recovers_rollback_restore_after_original_active_was_restored() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let previous = temp.0.join("binaries.previous");
+        let restore_swap = temp.0.join(RESTORE_SWAP_NAME);
+        fixture(&active, "2.0.0");
+        manifest("2.0.0").write_atomic(&active).unwrap();
+        fixture(&restore_swap, "1.0.0");
+        manifest("1.0.0").write_atomic(&restore_swap).unwrap();
+
+        let installation = CoreInstallation::new(&active).unwrap();
+        installation.recover().unwrap();
+        installation.recover().unwrap();
+
+        assert_eq!(CoreManifest::read(&active).unwrap().version, "2.0.0");
+        assert_eq!(CoreManifest::read(&previous).unwrap().version, "1.0.0");
+        assert!(!restore_swap.exists());
+    }
+}

--- a/src-tauri/src/core/installation.rs
+++ b/src-tauri/src/core/installation.rs
@@ -25,6 +25,8 @@ const ACTIVE_FAKE_FILES: [&str; 2] = ["ACTIVE_DISCORD_UDP.bin", "ACTIVE_GAME_UDP
 pub struct CoreManifest {
     pub schema_version: u32,
     pub provider: String,
+    #[serde(default)]
+    pub channel: Option<String>,
     pub version: String,
     pub source_url: Option<String>,
     pub checksum: Option<Checksum>,
@@ -45,6 +47,7 @@ impl CoreManifest {
         Self {
             schema_version: SCHEMA_VERSION,
             provider,
+            channel: None,
             version,
             source_url,
             checksum,
@@ -241,8 +244,22 @@ impl CoreInstallation {
     ) -> Result<(), String> {
         self.assert_staging(staging)?;
         CoreManifest::read(staging)?;
-        if !self.active.is_dir() {
-            return Err("Active core is missing".into());
+        if !self.active.exists() {
+            if self.previous.exists() {
+                return Err("Cannot perform first activation while a previous core exists".into());
+            }
+            fs::rename(staging, &self.active)
+                .map_err(|e| format!("Cannot activate first core: {e}"))?;
+            if let Err(error) = active_provider.validate_installation() {
+                self.assert_owned(&self.active, "binaries")?;
+                fs::remove_dir_all(&self.active).map_err(|cleanup| {
+                    format!(
+                        "Post-activation validation failed ({error}); cleanup failed: {cleanup}"
+                    )
+                })?;
+                return Err(format!("Post-activation validation failed: {error}"));
+            }
+            return Ok(());
         }
         self.preserve_user_files(&self.active, staging)?;
         let previous_backup = self.parent.join(PREVIOUS_BACKUP_NAME);
@@ -791,6 +808,45 @@ mod tests {
         assert_eq!(CoreManifest::read(&active).unwrap().version, "2.0.0");
         assert_eq!(CoreManifest::read(&previous).unwrap().version, "1.0.0");
         assert!(!temp.0.join(PREVIOUS_BACKUP_NAME).exists());
+    }
+
+    #[test]
+    fn successful_first_install_has_no_rollback() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let installation = CoreInstallation::new(&active).unwrap();
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        installation
+            .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+            .unwrap();
+        installation.activate(&staging, provider(&active)).unwrap();
+        assert_eq!(CoreManifest::read(&active).unwrap().version, "2.0.0");
+        assert!(!installation.state().rollback_available);
+        assert!(installation
+            .rollback(provider(&active), provider(&active))
+            .is_err());
+        installation.recover().unwrap();
+        installation.recover().unwrap();
+        assert!(active.exists());
+    }
+
+    #[test]
+    fn failed_first_install_leaves_no_partial_active_core() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let installation = CoreInstallation::new(&active).unwrap();
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        installation
+            .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+            .unwrap();
+        fs::remove_file(staging.join("service.bat")).unwrap();
+        assert!(installation.activate(&staging, provider(&active)).is_err());
+        assert!(!active.exists());
+        installation.recover().unwrap();
+        installation.recover().unwrap();
+        assert!(!active.exists());
     }
 
     #[test]

--- a/src-tauri/src/core/manager.rs
+++ b/src-tauri/src/core/manager.rs
@@ -1,0 +1,34 @@
+use std::path::PathBuf;
+
+use crate::providers::FlowsealProvider;
+
+use super::{CoreProvider, CoreRelease};
+
+/// Composition root for the active core. Flowseal is selected here only; UI
+/// and Tauri command orchestration depend on the provider-neutral interface.
+pub struct CoreManager {
+    provider: FlowsealProvider,
+}
+
+impl CoreManager {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            provider: FlowsealProvider::new(root),
+        }
+    }
+
+    pub fn provider(&self) -> &dyn CoreProvider {
+        &self.provider
+    }
+
+    pub async fn fetch_fallback_release(
+        &self,
+        client: &reqwest::Client,
+    ) -> Result<CoreRelease, String> {
+        self.provider.fetch_fallback_release(client).await
+    }
+
+    pub fn fallback_latest_url(&self) -> &'static str {
+        self.provider.fallback_latest_url()
+    }
+}

--- a/src-tauri/src/core/manager.rs
+++ b/src-tauri/src/core/manager.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use crate::providers::FlowsealProvider;
 
-use super::{CoreProvider, CoreRelease};
+use super::CoreProvider;
 
 /// Composition root for the active core. Flowseal is selected here only; UI
 /// and Tauri command orchestration depend on the provider-neutral interface.
@@ -19,16 +19,5 @@ impl CoreManager {
 
     pub fn provider(&self) -> &dyn CoreProvider {
         &self.provider
-    }
-
-    pub async fn fetch_fallback_release(
-        &self,
-        client: &reqwest::Client,
-    ) -> Result<CoreRelease, String> {
-        self.provider.fetch_fallback_release(client).await
-    }
-
-    pub fn fallback_latest_url(&self) -> &'static str {
-        self.provider.fallback_latest_url()
     }
 }

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -4,8 +4,8 @@ mod manager;
 mod paths;
 mod provider;
 
-pub use channel::{compare_versions, resolve_stable, CoreUpdateStatus, StableManifest};
+pub use channel::{compare_versions, resolve_stable, CoreUpdateStatus};
 pub use installation::{CoreInstallation, CoreInstallationState, CoreManifest};
 pub use manager::CoreManager;
 pub use paths::CorePaths;
-pub use provider::{Checksum, CoreProvider};
+pub use provider::{Checksum, CoreArtifact, CoreProvider, CoreRelease};

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -1,9 +1,11 @@
+mod channel;
 mod installation;
 mod manager;
 mod paths;
 mod provider;
 
-pub use installation::{CoreInstallation, CoreInstallationState};
+pub use channel::{compare_versions, resolve_stable, CoreUpdateStatus, StableManifest};
+pub use installation::{CoreInstallation, CoreInstallationState, CoreManifest};
 pub use manager::CoreManager;
 pub use paths::CorePaths;
-pub use provider::{Checksum, CoreProvider, CoreRelease};
+pub use provider::{Checksum, CoreProvider};

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -1,7 +1,9 @@
+mod installation;
 mod manager;
 mod paths;
 mod provider;
 
+pub use installation::{CoreInstallation, CoreInstallationState};
 pub use manager::CoreManager;
 pub use paths::CorePaths;
 pub use provider::{Checksum, CoreProvider, CoreRelease};

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -1,0 +1,5 @@
+mod paths;
+mod provider;
+
+pub use paths::CorePaths;
+pub use provider::{CoreProvider, FallbackRelease};

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -1,5 +1,7 @@
+mod manager;
 mod paths;
 mod provider;
 
+pub use manager::CoreManager;
 pub use paths::CorePaths;
-pub use provider::{CoreProvider, FallbackRelease};
+pub use provider::{Checksum, CoreProvider, CoreRelease};

--- a/src-tauri/src/core/paths.rs
+++ b/src-tauri/src/core/paths.rs
@@ -1,0 +1,39 @@
+use std::path::{Path, PathBuf};
+
+/// Paths shared by the application and the installed core provider.
+#[derive(Clone, Debug)]
+pub struct CorePaths {
+    root: PathBuf,
+}
+
+impl CorePaths {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+    pub fn bin_dir(&self) -> PathBuf {
+        self.root.join("bin")
+    }
+    pub fn lists_dir(&self) -> PathBuf {
+        self.root.join("lists")
+    }
+    pub fn utils_dir(&self) -> PathBuf {
+        self.root.join("utils")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exposes_standard_core_directories() {
+        let paths = CorePaths::new("core");
+        assert_eq!(paths.bin_dir(), PathBuf::from("core/bin"));
+        assert_eq!(paths.lists_dir(), PathBuf::from("core/lists"));
+        assert_eq!(paths.utils_dir(), PathBuf::from("core/utils"));
+    }
+}

--- a/src-tauri/src/core/provider.rs
+++ b/src-tauri/src/core/provider.rs
@@ -17,7 +17,7 @@ pub struct CoreRelease {
 }
 
 /// Boundary between Tauri/core orchestration and an upstream core distribution.
-pub trait CoreProvider {
+pub trait CoreProvider: Send + Sync {
     fn paths(&self) -> &CorePaths;
     fn version_url(&self) -> &'static str;
     fn release_api_url(&self, version: &str) -> String;

--- a/src-tauri/src/core/provider.rs
+++ b/src-tauri/src/core/provider.rs
@@ -1,8 +1,10 @@
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 use super::CorePaths;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "algorithm", content = "value", rename_all = "lowercase")]
 pub enum Checksum {
     Sha256(String),
     Md5(String),
@@ -18,6 +20,7 @@ pub struct CoreRelease {
 
 /// Boundary between Tauri/core orchestration and an upstream core distribution.
 pub trait CoreProvider: Send + Sync {
+    fn provider_name(&self) -> &'static str;
     fn paths(&self) -> &CorePaths;
     fn version_url(&self) -> &'static str;
     fn release_api_url(&self, version: &str) -> String;
@@ -31,4 +34,6 @@ pub trait CoreProvider: Send + Sync {
     fn is_installed(&self) -> bool;
     fn strategies(&self) -> Result<Vec<String>, String>;
     fn parse_strategy(&self, strategy: &str, game_filter: &str) -> Result<String, String>;
+    /// Validates provider-specific on-disk structure and returns its version and strategy count.
+    fn validate_installation(&self) -> Result<(String, usize), String>;
 }

--- a/src-tauri/src/core/provider.rs
+++ b/src-tauri/src/core/provider.rs
@@ -12,20 +12,24 @@ pub enum Checksum {
 
 /// Download information without assumptions about a provider's hosting service.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub struct CoreArtifact {
+    pub url: String,
+    pub checksum: Checksum,
+}
+
+#[allow(dead_code)]
 pub struct CoreRelease {
+    pub provider: String,
+    pub channel: String,
     pub version: String,
-    pub download_url: String,
-    pub checksum: Option<Checksum>,
+    pub artifacts: Vec<CoreArtifact>,
 }
 
 /// Boundary between Tauri/core orchestration and an upstream core distribution.
 pub trait CoreProvider: Send + Sync {
     fn provider_name(&self) -> &'static str;
     fn paths(&self) -> &CorePaths;
-    fn version_url(&self) -> &'static str;
-    fn release_api_url(&self, version: &str) -> String;
-    fn archive_name(&self, version: &str) -> String;
-    fn release_download_url(&self, version: &str) -> String;
     fn ipset_url(&self) -> &'static str;
     fn service_script(&self) -> PathBuf;
     fn test_script(&self) -> PathBuf;

--- a/src-tauri/src/core/provider.rs
+++ b/src-tauri/src/core/provider.rs
@@ -7,18 +7,19 @@ use super::CorePaths;
 #[serde(tag = "algorithm", content = "value", rename_all = "lowercase")]
 pub enum Checksum {
     Sha256(String),
+    // Kept only to deserialize schema-v1 installation manifests created by
+    // the former SourceForge updater. Managed channel artifacts never create it.
     Md5(String),
 }
 
 /// Download information without assumptions about a provider's hosting service.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[allow(dead_code)]
 pub struct CoreArtifact {
     pub url: String,
     pub checksum: Checksum,
 }
 
-#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CoreRelease {
     pub provider: String,
     pub channel: String,

--- a/src-tauri/src/core/provider.rs
+++ b/src-tauri/src/core/provider.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+
+use super::CorePaths;
+
+#[derive(Clone, Debug)]
+pub struct FallbackRelease {
+    pub version: String,
+    pub download_url: String,
+    pub md5sum: String,
+}
+
+/// Boundary between Tauri/core orchestration and an upstream core distribution.
+pub trait CoreProvider {
+    fn id(&self) -> &'static str;
+    fn paths(&self) -> &CorePaths;
+    fn version_url(&self) -> &'static str;
+    fn release_api_url(&self, version: &str) -> String;
+    fn archive_name(&self, version: &str) -> String;
+    fn release_download_url(&self, version: &str) -> String;
+    fn fallback_metadata_url(&self) -> &'static str;
+    fn fallback_latest_url(&self) -> &'static str;
+    fn ipset_url(&self) -> &'static str;
+    fn service_script(&self) -> PathBuf;
+    fn test_script(&self) -> PathBuf;
+    fn winws_executable(&self) -> PathBuf;
+    fn local_version(&self) -> String;
+    fn is_installed(&self) -> bool;
+    fn strategies(&self) -> Result<Vec<String>, String>;
+    fn parse_strategy(&self, strategy: &str, game_filter: &str) -> Result<String, String>;
+}

--- a/src-tauri/src/core/provider.rs
+++ b/src-tauri/src/core/provider.rs
@@ -2,23 +2,27 @@ use std::path::PathBuf;
 
 use super::CorePaths;
 
-#[derive(Clone, Debug)]
-pub struct FallbackRelease {
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Checksum {
+    Sha256(String),
+    Md5(String),
+}
+
+/// Download information without assumptions about a provider's hosting service.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CoreRelease {
     pub version: String,
     pub download_url: String,
-    pub md5sum: String,
+    pub checksum: Option<Checksum>,
 }
 
 /// Boundary between Tauri/core orchestration and an upstream core distribution.
 pub trait CoreProvider {
-    fn id(&self) -> &'static str;
     fn paths(&self) -> &CorePaths;
     fn version_url(&self) -> &'static str;
     fn release_api_url(&self, version: &str) -> String;
     fn archive_name(&self, version: &str) -> String;
     fn release_download_url(&self, version: &str) -> String;
-    fn fallback_metadata_url(&self) -> &'static str;
-    fn fallback_latest_url(&self) -> &'static str;
     fn ipset_url(&self) -> &'static str;
     fn service_script(&self) -> PathBuf;
     fn test_script(&self) -> PathBuf;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,7 +33,10 @@ use tauri_plugin_notification::NotificationExt;
 
 mod core;
 mod providers;
-use core::{Checksum, CoreInstallation, CoreInstallationState, CoreManager, CoreRelease};
+use core::{
+    compare_versions, resolve_stable, Checksum, CoreInstallation, CoreInstallationState,
+    CoreManager, CoreUpdateStatus,
+};
 
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 const GITHUB_USER_AGENT: &str = "zapret-ui-updater";
@@ -382,92 +385,6 @@ fn hex_encode(bytes: &[u8]) -> String {
 
 /// Fetches the expected SHA-256 digest of the given release asset from the
 /// GitHub Releases API. Returns a lowercase hex string on success.
-async fn fetch_expected_sha256(version: &str, asset_name: &str) -> Result<String, String> {
-    if version.is_empty()
-        || !version
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | '+'))
-    {
-        return Err(format!("Invalid upstream version tag: {}", version));
-    }
-
-    let url = core_manager().provider().release_api_url(version);
-    let client = reqwest::Client::builder()
-        .user_agent(GITHUB_USER_AGENT)
-        .build()
-        .map_err(|e| format!("Failed to build HTTP client: {}", e))?;
-
-    let resp = client
-        .get(&url)
-        .header("Accept", "application/vnd.github+json")
-        .send()
-        .await
-        .map_err(|e| format!("Failed to fetch release metadata: {}", e))?;
-
-    if !resp.status().is_success() {
-        return Err(format!(
-            "GitHub API returned status {} for {}",
-            resp.status(),
-            url
-        ));
-    }
-
-    let body: serde_json::Value = resp
-        .json()
-        .await
-        .map_err(|e| format!("Failed to parse release metadata: {}", e))?;
-
-    let assets = body
-        .get("assets")
-        .and_then(|a| a.as_array())
-        .ok_or_else(|| "Release metadata is missing assets".to_string())?;
-
-    let asset = assets
-        .iter()
-        .find(|a| a.get("name").and_then(|n| n.as_str()) == Some(asset_name))
-        .ok_or_else(|| format!("Asset {} not found in release {}", asset_name, version))?;
-
-    let digest = asset
-        .get("digest")
-        .and_then(|d| d.as_str())
-        .ok_or_else(|| format!("Asset {} has no digest field", asset_name))?;
-
-    let hex = digest
-        .strip_prefix("sha256:")
-        .ok_or_else(|| format!("Unsupported digest format: {}", digest))?;
-
-    if hex.len() != 64 || !hex.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err(format!("Malformed sha256 digest: {}", digest));
-    }
-
-    Ok(hex.to_ascii_lowercase())
-}
-
-pub async fn fetch_fallback_release_info(client: &reqwest::Client) -> Result<CoreRelease, String> {
-    core_manager().fetch_fallback_release(client).await
-}
-
-/// Computes the MD5 digest of a file as a lowercase hex string.
-pub fn md5_file(path: &std::path::Path) -> Result<String, String> {
-    use std::io::Read;
-
-    let mut file = std::fs::File::open(path)
-        .map_err(|e| format!("Failed to open {}: {}", path.display(), e))?;
-    let mut context = md5::Context::new();
-    let mut buf = [0u8; 64 * 1024];
-    loop {
-        let n = file
-            .read(&mut buf)
-            .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
-        if n == 0 {
-            break;
-        }
-        context.consume(&buf[..n]);
-    }
-    let digest = context.compute();
-    Ok(format!("{:x}", digest))
-}
-
 /// On Windows, `std::fs::canonicalize` returns the verbatim/extended-length
 /// form (e.g. `\\?\C:\foo\bar`). That form is fine for Rust's file APIs but
 /// breaks `cmd.exe` and downstream `.bat` scripts, which refuse to use it as
@@ -649,40 +566,50 @@ async fn get_remote_core_version(
 
     let client = client_builder.build().map_err(|e| e.to_string())?;
 
-    let response_res = client
-        .get(core_manager().provider().version_url())
-        .send()
-        .await;
+    Ok(resolve_stable(
+        &client,
+        core_manager().provider().provider_name(),
+        GITHUB_USER_AGENT,
+    )
+    .await?
+    .version)
+}
 
-    match response_res {
-        Ok(resp) => {
-            let status = resp.status();
-            if status.is_success() {
-                if let Ok(text) = resp.text().await {
-                    let trimmed = text.trim();
-                    if !trimmed.is_empty() && !trimmed.contains("Not Found") {
-                        return Ok(trimmed.to_string());
-                    }
-                }
-            }
-            if let Ok(info) = fetch_fallback_release_info(&client).await {
-                return Ok(info.version);
-            }
-            Err(format!(
-                "GitHub returned status {} and SourceForge fallback failed",
-                status
-            ))
-        }
-        Err(e) => {
-            if let Ok(info) = fetch_fallback_release_info(&client).await {
-                return Ok(info.version);
-            }
-            Err(format!(
-                "Failed to connect to GitHub ({}) and SourceForge fallback failed",
-                e
-            ))
-        }
-    }
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CoreUpdateInfo {
+    provider: String,
+    channel: String,
+    current_version: Option<String>,
+    stable_version: String,
+    status: CoreUpdateStatus,
+    update_available: bool,
+}
+
+#[tauri::command]
+async fn get_core_update_info(
+    use_proxy: Option<bool>,
+    custom_proxy: Option<String>,
+) -> Result<CoreUpdateInfo, String> {
+    let stable = get_remote_core_version(use_proxy, custom_proxy).await?;
+    let provider = core_manager().provider();
+    let current = provider.is_installed().then(|| provider.local_version());
+    let status = current
+        .as_deref()
+        .map_or(CoreUpdateStatus::NotInstalled, |local| {
+            compare_versions(local, &stable)
+        });
+    Ok(CoreUpdateInfo {
+        provider: provider.provider_name().into(),
+        channel: "stable".into(),
+        current_version: current,
+        stable_version: stable,
+        status,
+        update_available: matches!(
+            status,
+            CoreUpdateStatus::NotInstalled | CoreUpdateStatus::UpdateAvailable
+        ),
+    })
 }
 
 fn get_ui_version() -> String {
@@ -1828,204 +1755,66 @@ async fn download_and_install_update(
         .build()
         .map_err(|e| format!("Failed to build http client: {}", e))?;
 
-    // Fetch version from GitHub with fallback to SourceForge
+    // Resolve the managed channel once; the same immutable release metadata is
+    // then used for every mirror attempt in this operation.
     let provider = manager.provider();
-    let mut fetched_from_sf = false;
-    let mut sf_info: Option<CoreRelease> = None;
-
-    let latest_version = match client
-        .get(provider.version_url())
-        .header("Cache-Control", "no-cache")
-        .send()
-        .await
-    {
-        Ok(resp) if resp.status().is_success() => match resp.text().await {
-            Ok(text) => {
-                let trimmed = text.trim().to_string();
-                if !trimmed.is_empty() && !trimmed.contains("Not Found") {
-                    trimmed
-                } else {
-                    fetched_from_sf = true;
-                    let info = fetch_fallback_release_info(&client).await?;
-                    let version = info.version.clone();
-                    sf_info = Some(info);
-                    version
-                }
+    let release = resolve_stable(&client, provider.provider_name(), GITHUB_USER_AGENT).await?;
+    let latest_version = release.version.clone();
+    if provider.is_installed() {
+        match compare_versions(&provider.local_version(), &latest_version) {
+            CoreUpdateStatus::Ahead | CoreUpdateStatus::Unknown => {
+                return Err(
+                    "The installed core cannot be safely updated to this stable release".into(),
+                )
             }
-            Err(_) => {
-                fetched_from_sf = true;
-                let info = fetch_fallback_release_info(&client).await?;
-                let version = info.version.clone();
-                sf_info = Some(info);
-                version
-            }
-        },
-        _ => {
-            fetched_from_sf = true;
-            let info = fetch_fallback_release_info(&client).await?;
-            let version = info.version.clone();
-            sf_info = Some(info);
-            version
+            CoreUpdateStatus::UpToDate => return Ok("Core is already up to date".into()),
+            _ => {}
         }
-    };
-
+    }
     window.emit("download-progress", 10).ok();
-
     let zip_path = temp_dir.join("update.zip");
-
-    use std::sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    };
-    let done_flag = Arc::new(AtomicBool::new(false));
-    let done_flag_thread = done_flag.clone();
-    let window_clone = window.clone();
-    std::thread::spawn(move || {
-        let steps: &[u16] = &[15, 20, 28, 35, 42, 50, 58, 65, 72, 78, 83, 88];
-        for pct in steps {
-            if done_flag_thread.load(Ordering::Relaxed) {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_secs(3));
-            if done_flag_thread.load(Ordering::Relaxed) {
-                break;
-            }
-            window_clone.emit("download-progress", *pct).ok();
-        }
-    });
-
-    // 1. Try downloading from GitHub
-    let mut response = None;
-    let mut downloaded_from_sf = false;
-
-    if !fetched_from_sf {
-        let github_url = provider.release_download_url(&latest_version);
-        if let Ok(resp) = client.get(&github_url).send().await {
-            if resp.status().is_success() {
-                response = Some(resp);
-            }
-        }
-    }
-
-    // 2. If GitHub failed or wasn't tried, try SourceForge
-    if response.is_none() {
-        // Ensure we have SF info loaded
-        let info = match sf_info {
-            Some(i) => i,
-            None => fetch_fallback_release_info(&client).await?,
-        };
-
-        // Try downloading from the direct SourceForge URL
-        match client.get(&info.download_url).send().await {
-            Ok(resp) if resp.status().is_success() => {
-                response = Some(resp);
-                downloaded_from_sf = true;
-                sf_info = Some(info);
-            }
-            _ => {
-                // Also try downloading from the generic latest URL user requested as fallback
-                let generic_url = manager.fallback_latest_url();
-                match client.get(generic_url).send().await {
-                    Ok(resp) if resp.status().is_success() => {
-                        response = Some(resp);
-                        downloaded_from_sf = true;
-                        sf_info = Some(info);
-                    }
-                    Ok(resp) => {
-                        done_flag.store(true, Ordering::Relaxed);
-                        return Err(format!(
-                            "SourceForge download failed with status: {}",
-                            resp.status()
-                        ));
-                    }
-                    Err(e) => {
-                        done_flag.store(true, Ordering::Relaxed);
-                        return Err(format!(
-                            "Failed to download from both GitHub and SourceForge. SF error: {}",
-                            e
-                        ));
-                    }
-                }
-            }
-        }
-    }
-
-    let response = response.unwrap();
-
     use futures_util::StreamExt;
-    let mut file = std::fs::File::create(&zip_path).map_err(|e| {
-        done_flag.store(true, Ordering::Relaxed);
-        format!("Failed to create update zip file: {}", e)
-    })?;
-
-    let mut stream = response.bytes_stream();
-    while let Some(chunk) = stream.next().await {
-        match chunk {
-            Ok(bytes) => {
-                use std::io::Write;
-                if let Err(e) = file.write_all(&bytes) {
-                    done_flag.store(true, Ordering::Relaxed);
-                    return Err(format!("Failed to write to zip file: {}", e));
-                }
-            }
-            Err(e) => {
-                done_flag.store(true, Ordering::Relaxed);
-                return Err(format!("Error while downloading: {}", e));
-            }
-        }
-    }
-
-    done_flag.store(true, Ordering::Relaxed);
-
-    if !zip_path.exists() {
-        return Err("Download failed: output file not found".to_string());
-    }
-
-    // Verify integrity of downloaded archive before extraction.
-    let verified_checksum;
-    let source_url;
-    if downloaded_from_sf {
-        if let Some(info) = sf_info {
-            let expected_md5 = match info.checksum {
-                Some(Checksum::Md5(value)) => value,
-                _ => {
-                    return Err(
-                        "Downloaded from SourceForge but MD5 metadata is missing".to_string()
-                    )
-                }
-            };
-            let actual_md5 = md5_file(&zip_path)?;
-            if actual_md5 != expected_md5.to_ascii_lowercase() {
-                let _ = std::fs::remove_file(&zip_path);
-                return Err(format!(
-                    "Checksum mismatch (MD5) for SourceForge download: expected {}, got {}",
-                    expected_md5, actual_md5
-                ));
-            }
-            verified_checksum = Checksum::Md5(expected_md5);
-            source_url = Some(info.download_url);
-        } else {
-            return Err("Downloaded from SourceForge but release metadata is missing".to_string());
-        }
-    } else {
-        let asset_name = provider.archive_name(&latest_version);
-        let expected_checksum =
-            Checksum::Sha256(fetch_expected_sha256(&latest_version, &asset_name).await?);
-        let expected_sha256 = match expected_checksum {
-            Checksum::Sha256(value) => value,
-            Checksum::Md5(_) => unreachable!("GitHub releases require SHA-256"),
+    let mut selected = None;
+    for artifact in &release.artifacts {
+        let _ = std::fs::remove_file(&zip_path);
+        let response = match client.get(&artifact.url).send().await {
+            Ok(response) if response.status().is_success() => response,
+            _ => continue,
         };
-        let actual_sha256 = sha256_file(&zip_path)?;
-        if actual_sha256 != expected_sha256 {
-            let _ = std::fs::remove_file(&zip_path);
-            return Err(format!(
-                "Checksum mismatch (SHA-256) for {}: expected {}, got {}",
-                asset_name, expected_sha256, actual_sha256
-            ));
+        let mut file = std::fs::File::create(&zip_path)
+            .map_err(|e| format!("Failed to create update archive: {e}"))?;
+        let mut stream = response.bytes_stream();
+        let mut failed = false;
+        while let Some(chunk) = stream.next().await {
+            match chunk {
+                Ok(bytes) => {
+                    use std::io::Write;
+                    if file.write_all(&bytes).is_err() {
+                        failed = true;
+                        break;
+                    }
+                }
+                Err(_) => {
+                    failed = true;
+                    break;
+                }
+            }
         }
-        verified_checksum = Checksum::Sha256(expected_sha256);
-        source_url = Some(provider.release_download_url(&latest_version));
+        drop(file);
+        if failed {
+            continue;
+        }
+        let actual = sha256_file(&zip_path)?;
+        if actual == artifact.checksum.value {
+            selected = Some((artifact.url.clone(), Checksum::Sha256(actual)));
+            break;
+        }
+        let _ = std::fs::remove_file(&zip_path);
+        eprintln!("Core artifact checksum mismatch: {}", artifact.url);
     }
+    let (source_url, verified_checksum) = selected
+        .map(|(url, checksum)| (Some(url), checksum))
+        .ok_or_else(|| "No stable core artifact could be downloaded and verified".to_string())?;
 
     // Extraction
     window.emit("download-progress", 92).ok();
@@ -2076,6 +1865,9 @@ async fn download_and_install_update(
         installation.remove_owned_staging(&staging)?;
         return Err(error);
     }
+    let mut installed_manifest = core::CoreManifest::read(&staging)?;
+    installed_manifest.channel = Some(release.channel.clone());
+    installed_manifest.write_atomic(&staging)?;
     installation.preserve_user_files(&dir, &staging)?;
 
     // Capture the exact runtime state only after the candidate is ready, just
@@ -3743,6 +3535,7 @@ pub fn run() {
             import_backup_file,
             update_ipset_list,
             get_remote_core_version,
+            get_core_update_info,
             download_and_install_update,
             get_core_installation_state,
             rollback_core_update,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,10 +33,31 @@ use tauri_plugin_notification::NotificationExt;
 
 mod core;
 mod providers;
-use core::{Checksum, CoreManager, CoreRelease};
+use core::{Checksum, CoreInstallation, CoreInstallationState, CoreManager, CoreRelease};
 
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 const GITHUB_USER_AGENT: &str = "zapret-ui-updater";
+static CORE_OPERATION_ACTIVE: AtomicBool = AtomicBool::new(false);
+static EXIT_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+
+struct CoreOperationGuard;
+
+impl CoreOperationGuard {
+    fn acquire() -> Result<Self, String> {
+        CORE_OPERATION_ACTIVE
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .map_err(|_| {
+                "Another core update or rollback operation is already in progress".to_string()
+            })?;
+        Ok(Self)
+    }
+}
+
+impl Drop for CoreOperationGuard {
+    fn drop(&mut self) {
+        CORE_OPERATION_ACTIVE.store(false, Ordering::Release);
+    }
+}
 
 struct AppState {
     active_strategy: Mutex<Option<String>>,
@@ -74,6 +95,23 @@ struct ZapretStatus {
     running: bool,
     strategy: Option<String>,
     mode: Option<String>,
+}
+
+fn restart_context(
+    status: ZapretStatus,
+    operation: &str,
+) -> Result<Option<(String, String)>, String> {
+    if !status.running {
+        return Ok(None);
+    }
+    Ok(Some((
+        status.strategy.ok_or_else(|| {
+            format!("Cannot {operation} while zapret is running: active strategy is unknown")
+        })?,
+        status.mode.ok_or_else(|| {
+            format!("Cannot {operation} while zapret is running: launch mode is unknown")
+        })?,
+    )))
 }
 
 #[derive(serde::Serialize)]
@@ -1743,37 +1781,34 @@ fn is_ip_or_cidr(s: &str) -> bool {
 
 #[tauri::command]
 async fn download_and_install_update(
+    app: tauri::AppHandle,
     window: tauri::Window,
     use_proxy: Option<bool>,
     custom_proxy: Option<String>,
+    state: State<'_, AppState>,
 ) -> Result<String, String> {
-    // Stop the zapret service and processes to release file locks before update
-    let _ = stop_zapret_internal();
-
-    let filters_status = get_filters_status();
+    let _operation_guard = CoreOperationGuard::acquire()?;
     let dir = find_binaries_dir();
-    let temp_dir = std::env::temp_dir().join("zapret_update");
+    let installation = CoreInstallation::new(&dir)?;
+    let manager = core_manager_at(&dir);
+    installation.prepare(manager.provider())?;
+    let temp_parent = std::env::temp_dir();
+    let temp_dir = temp_parent.join(format!(
+        ".zapret-ui-core-download-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| format!("System clock error: {e}"))?
+            .as_nanos()
+    ));
 
     // Create temp directory
-    let _ = std::fs::remove_dir_all(&temp_dir);
     std::fs::create_dir_all(&temp_dir).map_err(|e| format!("Failed to create temp dir: {}", e))?;
-
-    // Backup user files
-    let lists_dir = dir.join("lists");
-    let backup_dir = temp_dir.join("backup");
-    std::fs::create_dir_all(&backup_dir).ok();
-
-    if lists_dir.exists() {
-        if let Ok(entries) = std::fs::read_dir(&lists_dir) {
-            for entry in entries.flatten() {
-                if let Some(name) = entry.file_name().to_str() {
-                    if name.contains("user") {
-                        let _ = std::fs::copy(entry.path(), backup_dir.join(name));
-                    }
-                }
-            }
-        }
-    }
+    let _download_cleanup = OwnedDirectoryCleanup::new(
+        temp_dir.clone(),
+        temp_parent.canonicalize().map_err(|e| e.to_string())?,
+        ".zapret-ui-core-download-",
+    );
 
     window.emit("download-progress", 5).ok();
 
@@ -1794,7 +1829,6 @@ async fn download_and_install_update(
         .map_err(|e| format!("Failed to build http client: {}", e))?;
 
     // Fetch version from GitHub with fallback to SourceForge
-    let manager = core_manager_at(&dir);
     let provider = manager.provider();
     let mut fetched_from_sf = false;
     let mut sf_info: Option<CoreRelease> = None;
@@ -1947,7 +1981,9 @@ async fn download_and_install_update(
         return Err("Download failed: output file not found".to_string());
     }
 
-    // Verify integrity of downloaded archive
+    // Verify integrity of downloaded archive before extraction.
+    let verified_checksum;
+    let source_url;
     if downloaded_from_sf {
         if let Some(info) = sf_info {
             let expected_md5 = match info.checksum {
@@ -1966,6 +2002,8 @@ async fn download_and_install_update(
                     expected_md5, actual_md5
                 ));
             }
+            verified_checksum = Checksum::Md5(expected_md5);
+            source_url = Some(info.download_url);
         } else {
             return Err("Downloaded from SourceForge but release metadata is missing".to_string());
         }
@@ -1985,18 +2023,32 @@ async fn download_and_install_update(
                 asset_name, expected_sha256, actual_sha256
             ));
         }
+        verified_checksum = Checksum::Sha256(expected_sha256);
+        source_url = Some(provider.release_download_url(&latest_version));
     }
 
     // Extraction
     window.emit("download-progress", 92).ok();
-    let extract_dir = temp_dir.join("extracted");
-    let _ = std::fs::create_dir_all(&extract_dir);
+    let staging = installation.create_staging()?;
+    let _staging_cleanup = OwnedDirectoryCleanup::new(
+        staging.clone(),
+        staging
+            .parent()
+            .ok_or_else(|| "Staging has no parent".to_string())?
+            .to_path_buf(),
+        ".binaries-staging-",
+    );
+    let extract_dir = staging.join("package");
+    std::fs::create_dir(&extract_dir).map_err(|e| format!("Failed to prepare staging: {e}"))?;
 
     // Extract natively via the `zip` crate instead of calling
     // `Expand-Archive`. Every entry name is validated against `..`, absolute
     // paths, and drive-letter prefixes before it is written, preventing
     // zip-slip from placing files outside `extract_dir`.
-    extract_zip_safely(&zip_path, &extract_dir)?;
+    if let Err(error) = extract_zip_safely(&zip_path, &extract_dir) {
+        installation.remove_owned_staging(&staging)?;
+        return Err(error);
+    }
 
     window.emit("download-progress", 95).ok();
 
@@ -2008,25 +2060,258 @@ async fn download_and_install_update(
         }
     }
 
-    copy_dir_contents(&extracted_folder, &dir)?;
+    if let Err(error) = copy_dir_contents(&extracted_folder, &staging) {
+        installation.remove_owned_staging(&staging)?;
+        return Err(error);
+    }
+    std::fs::remove_dir_all(&extract_dir)
+        .map_err(|e| format!("Cannot remove staging package directory: {e}"))?;
+    if let Err(error) = installation.validate_and_manifest(
+        &staging,
+        &latest_version,
+        source_url,
+        Some(verified_checksum),
+        core_manager_at(&staging).provider(),
+    ) {
+        installation.remove_owned_staging(&staging)?;
+        return Err(error);
+    }
+    installation.preserve_user_files(&dir, &staging)?;
 
-    // Restore
-    let new_lists_dir = dir.join("lists");
-    let _ = std::fs::create_dir_all(&new_lists_dir);
-    if let Ok(entries) = std::fs::read_dir(&backup_dir) {
-        for entry in entries.flatten() {
-            let _ = std::fs::copy(entry.path(), new_lists_dir.join(entry.file_name()));
+    // Capture the exact runtime state only after the candidate is ready, just
+    // before stopping anything managed by the application.
+    let restart = restart_context(get_zapret_status(state.clone()), "update")?;
+    let filters_status = get_filters_status();
+    if restart.is_some() {
+        if let Err(error) = stop_zapret_internal() {
+            installation.remove_owned_staging(&staging)?;
+            return Err(format!("Cannot stop zapret before activation: {error}"));
         }
     }
 
-    // Restore settings after update
-    let _ = set_game_filter(filters_status.game_filter);
-    let _ = set_ipset_filter(filters_status.ipset);
+    let operation = (|| {
+        installation.activate(&staging, manager.provider())?;
+        if let Err(error) = set_game_filter(filters_status.game_filter)
+            .and_then(|_| set_ipset_filter(filters_status.ipset))
+        {
+            installation
+                .rollback(
+                    manager.provider(),
+                    core_manager_at(dir.with_file_name("binaries.previous")).provider(),
+                )
+                .map_err(|rollback| {
+                    format!(
+                        "Cannot restore filter settings ({error}); automatic rollback failed: {rollback}"
+                    )
+                })?;
+            return Err(format!(
+                "Cannot restore filter settings ({error}); automatic rollback completed"
+            ));
+        }
+        Ok(())
+    })();
 
-    let _ = std::fs::remove_dir_all(&temp_dir);
-    window.emit("download-progress", 100).ok();
+    let restart_result = restart.map(|(strategy, mode)| {
+        start_zapret(app, strategy, mode, state)
+            .map(|_| ())
+            .map_err(|e| format!("Cannot restart zapret after core update: {e}"))
+    });
+    match (operation, restart_result) {
+        (Err(error), Some(Err(restart_error))) => Err(format!("{error}; {restart_error}")),
+        (Err(error), _) => Err(error),
+        (Ok(()), Some(Err(restart_error))) => {
+            window.emit("download-progress", 100).ok();
+            Ok(format!("Update successful. Warning: {restart_error}"))
+        }
+        (Ok(()), _) => {
+            window.emit("download-progress", 100).ok();
+            Ok("Update successful".to_string())
+        }
+    }
+}
 
-    Ok("Update successful".to_string())
+struct OwnedDirectoryCleanup {
+    path: PathBuf,
+    expected_parent: PathBuf,
+    prefix: &'static str,
+}
+
+impl OwnedDirectoryCleanup {
+    fn new(path: PathBuf, expected_parent: PathBuf, prefix: &'static str) -> Self {
+        Self {
+            path,
+            expected_parent,
+            prefix,
+        }
+    }
+}
+
+impl Drop for OwnedDirectoryCleanup {
+    fn drop(&mut self) {
+        if !self.path.exists() {
+            return;
+        }
+        let actual_parent = self
+            .path
+            .parent()
+            .and_then(|parent| parent.canonicalize().ok());
+        let expected_parent = self.expected_parent.canonicalize().ok();
+        let owned = actual_parent == expected_parent
+            && self
+                .path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(self.prefix));
+        let safe_type = std::fs::symlink_metadata(&self.path)
+            .map(|metadata| !metadata.file_type().is_symlink())
+            .unwrap_or(false);
+        if owned && safe_type {
+            if let Err(error) = std::fs::remove_dir_all(&self.path) {
+                eprintln!(
+                    "Cannot clean owned temporary directory {}: {error}",
+                    self.path.display()
+                );
+            }
+        } else {
+            eprintln!(
+                "Refusing to clean unverified temporary directory {}",
+                self.path.display()
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod temporary_cleanup_tests {
+    use super::{restart_context, CoreOperationGuard, OwnedDirectoryCleanup, ZapretStatus};
+
+    #[test]
+    fn restart_context_preserves_service_and_temporary_modes() {
+        for mode in ["service", "temporary"] {
+            let context = restart_context(
+                ZapretStatus {
+                    running: true,
+                    strategy: Some("ALT12".to_string()),
+                    mode: Some(mode.to_string()),
+                },
+                "update",
+            )
+            .unwrap();
+            assert_eq!(context, Some(("ALT12".to_string(), mode.to_string())));
+        }
+        assert_eq!(
+            restart_context(
+                ZapretStatus {
+                    running: false,
+                    strategy: None,
+                    mode: None,
+                },
+                "update",
+            )
+            .unwrap(),
+            None
+        );
+        assert!(restart_context(
+            ZapretStatus {
+                running: true,
+                strategy: None,
+                mode: Some("service".to_string()),
+            },
+            "update",
+        )
+        .unwrap_err()
+        .contains("active strategy is unknown"));
+    }
+
+    #[test]
+    fn core_operation_guard_rejects_overlap_and_resets_on_drop() {
+        let guard = CoreOperationGuard::acquire().unwrap();
+        assert!(CoreOperationGuard::acquire()
+            .err()
+            .unwrap()
+            .contains("already in progress"));
+        drop(guard);
+        assert!(CoreOperationGuard::acquire().is_ok());
+    }
+
+    #[test]
+    fn owned_temporary_directory_is_cleaned_during_error_unwind() {
+        let temp_parent = std::env::temp_dir();
+        let expected_parent = temp_parent.canonicalize().unwrap();
+        for prefix in [".zapret-ui-core-download-", ".binaries-staging-"] {
+            let path = temp_parent.join(format!("{prefix}test-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir(&path).unwrap();
+            let result: Result<(), &str> = (|| {
+                let _cleanup =
+                    OwnedDirectoryCleanup::new(path.clone(), expected_parent.clone(), prefix);
+                Err("simulated failure")
+            })();
+            assert!(result.is_err());
+            assert!(!path.exists());
+        }
+    }
+}
+
+#[tauri::command]
+fn get_core_installation_state() -> Result<CoreInstallationState, String> {
+    let dir = find_binaries_dir();
+    let installation = CoreInstallation::new(&dir)?;
+    installation.prepare(core_manager_at(dir).provider())?;
+    Ok(installation.state())
+}
+
+#[tauri::command]
+fn rollback_core_update(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Result<CoreInstallationState, String> {
+    let _operation_guard = CoreOperationGuard::acquire()?;
+    let dir = find_binaries_dir();
+    let previous_dir = dir.with_file_name("binaries.previous");
+    let installation = CoreInstallation::new(&dir)?;
+    let active_manager = core_manager_at(&dir);
+    installation.prepare(active_manager.provider())?;
+    let filters = get_filters_status();
+    let restart = restart_context(get_zapret_status(state.clone()), "rollback")?;
+    if restart.is_some() {
+        stop_zapret_internal().map_err(|e| format!("Cannot stop zapret before rollback: {e}"))?;
+    }
+
+    let operation = (|| {
+        let result = installation.rollback(
+            active_manager.provider(),
+            core_manager_at(&previous_dir).provider(),
+        )?;
+        if let Err(error) =
+            set_game_filter(filters.game_filter).and_then(|_| set_ipset_filter(filters.ipset))
+        {
+            installation
+                .rollback(
+                    active_manager.provider(),
+                    core_manager_at(&previous_dir).provider(),
+                )
+                .map_err(|restore| {
+                    format!(
+                        "Cannot restore settings after rollback ({error}); cannot undo rollback: {restore}"
+                    )
+                })?;
+            return Err(format!(
+                "Cannot restore settings after rollback ({error}); original core restored"
+            ));
+        }
+        Ok(result)
+    })();
+
+    let restart_result = restart.map(|(strategy, mode)| {
+        start_zapret(app, strategy, mode, state)
+            .map_err(|e| format!("Cannot restart zapret after rollback attempt: {e}"))
+    });
+    match (operation, restart_result) {
+        (Ok(_), Some(Err(error))) => Err(error),
+        (Err(error), Some(Err(restart))) => Err(format!("{error}; {restart}")),
+        (result, _) => result,
+    }
 }
 
 /// Recursively copies directory contents
@@ -3177,8 +3462,21 @@ fn refresh_tray_menu(app: &tauri::AppHandle) {
 }
 
 #[tauri::command]
-fn exit_app(app: tauri::AppHandle, state: State<'_, AppState>) {
-    stop_zapret_on_exit(state);
+fn exit_app(app: tauri::AppHandle) {
+    graceful_exit(&app);
+}
+
+fn graceful_exit(app: &tauri::AppHandle) {
+    if EXIT_IN_PROGRESS.swap(true, Ordering::AcqRel) {
+        return;
+    }
+
+    stop_zapret_on_exit(app.state::<AppState>());
+    if let Some(window) = app.get_webview_window("main") {
+        if let Err(error) = window.destroy() {
+            eprintln!("Failed to destroy main WebView window during shutdown: {error}");
+        }
+    }
     app.exit(0);
 }
 
@@ -3285,9 +3583,7 @@ pub fn run() {
                 .on_menu_event(move |app, event| {
                     match event.id.as_ref() {
                         "quit" => {
-                            let state = app.state::<AppState>();
-                            stop_zapret_on_exit(state);
-                            app.exit(0);
+                            graceful_exit(app);
                         }
                         "show" => {
                             if let Some(window) = app.get_webview_window("main") {
@@ -3448,6 +3744,8 @@ pub fn run() {
             update_ipset_list,
             get_remote_core_version,
             download_and_install_update,
+            get_core_installation_state,
+            rollback_core_update,
             run_diagnostics,
             clear_discord_cache,
             check_admin_privileges,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,8 +33,7 @@ use tauri_plugin_notification::NotificationExt;
 
 mod core;
 mod providers;
-use core::CoreProvider;
-use providers::{parse_fallback_release, FlowsealProvider};
+use core::{Checksum, CoreManager, CoreRelease};
 
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 const GITHUB_USER_AGENT: &str = "zapret-ui-updater";
@@ -354,7 +353,7 @@ async fn fetch_expected_sha256(version: &str, asset_name: &str) -> Result<String
         return Err(format!("Invalid upstream version tag: {}", version));
     }
 
-    let url = FlowsealProvider::new(find_binaries_dir()).release_api_url(version);
+    let url = core_manager().provider().release_api_url(version);
     let client = reqwest::Client::builder()
         .user_agent(GITHUB_USER_AGENT)
         .build()
@@ -406,27 +405,8 @@ async fn fetch_expected_sha256(version: &str, asset_name: &str) -> Result<String
     Ok(hex.to_ascii_lowercase())
 }
 
-pub type SfReleaseInfo = core::FallbackRelease;
-
-pub async fn fetch_sf_release_info(client: &reqwest::Client) -> Result<SfReleaseInfo, String> {
-    let provider = FlowsealProvider::new(find_binaries_dir());
-    let response = client
-        .get(provider.fallback_metadata_url())
-        .header("Cache-Control", "no-cache")
-        .send()
-        .await
-        .map_err(|e| format!("Failed to send SourceForge request: {}", e))?;
-    if !response.status().is_success() {
-        return Err(format!(
-            "SourceForge returned status: {}",
-            response.status()
-        ));
-    }
-    let body: serde_json::Value = response
-        .json()
-        .await
-        .map_err(|e| format!("Failed to parse SourceForge JSON: {}", e))?;
-    parse_fallback_release(&body)
+pub async fn fetch_fallback_release_info(client: &reqwest::Client) -> Result<CoreRelease, String> {
+    core_manager().fetch_fallback_release(client).await
 }
 
 /// Computes the MD5 digest of a file as a lowercase hex string.
@@ -541,6 +521,14 @@ fn find_binaries_dir() -> PathBuf {
     PathBuf::from("binaries")
 }
 
+fn core_manager_at(root: impl Into<PathBuf>) -> CoreManager {
+    CoreManager::new(root)
+}
+
+fn core_manager() -> CoreManager {
+    core_manager_at(find_binaries_dir())
+}
+
 fn is_admin() -> bool {
     // net session — самый быстрый и надежный способ проверки прав администратора на Windows
     Command::new(system32_tool("net.exe"))
@@ -590,7 +578,7 @@ fn elevate_if_needed() {
 }
 
 fn get_local_version() -> String {
-    FlowsealProvider::new(find_binaries_dir()).local_version()
+    core_manager().provider().local_version()
 }
 
 #[tauri::command]
@@ -624,7 +612,7 @@ async fn get_remote_core_version(
     let client = client_builder.build().map_err(|e| e.to_string())?;
 
     let response_res = client
-        .get(FlowsealProvider::new(find_binaries_dir()).version_url())
+        .get(core_manager().provider().version_url())
         .send()
         .await;
 
@@ -639,7 +627,7 @@ async fn get_remote_core_version(
                     }
                 }
             }
-            if let Ok(info) = fetch_sf_release_info(&client).await {
+            if let Ok(info) = fetch_fallback_release_info(&client).await {
                 return Ok(info.version);
             }
             Err(format!(
@@ -648,7 +636,7 @@ async fn get_remote_core_version(
             ))
         }
         Err(e) => {
-            if let Ok(info) = fetch_sf_release_info(&client).await {
+            if let Ok(info) = fetch_fallback_release_info(&client).await {
                 return Ok(info.version);
             }
             Err(format!(
@@ -671,7 +659,7 @@ fn get_ui_version_cmd() -> String {
 
 #[tauri::command]
 fn ensure_binaries_present() -> bool {
-    FlowsealProvider::new(find_binaries_dir()).is_installed()
+    core_manager().provider().is_installed()
 }
 
 fn parse_bat_args(strategy: &str) -> Result<String, String> {
@@ -679,7 +667,9 @@ fn parse_bat_args(strategy: &str) -> Result<String, String> {
         return Err(format!("Invalid strategy name: {}", strategy));
     }
     let filters = get_filters_status();
-    FlowsealProvider::new(find_binaries_dir()).parse_strategy(strategy, &filters.game_filter)
+    core_manager()
+        .provider()
+        .parse_strategy(strategy, &filters.game_filter)
 }
 
 /// Splits a command-line arguments string into separate arguments, respecting double quotes
@@ -878,7 +868,7 @@ fn check_status_full() -> Result<String, String> {
 /// Список стратегий — имена .bat файлов из binaries/ (без service.bat).
 #[tauri::command]
 fn get_strategies() -> Result<Vec<String>, String> {
-    FlowsealProvider::new(find_binaries_dir()).strategies()
+    core_manager().provider().strategies()
 }
 
 /// Compare strings using natural sort (numbers compared numerically)
@@ -1282,7 +1272,7 @@ fn start_zapret(
         // the registry. That way the service points at the *real* executable
         // under `binaries/bin/`, not at a symlink that could later be
         // redirected to an attacker-controlled binary.
-        let bin_path_raw = FlowsealProvider::new(&dir).winws_executable();
+        let bin_path_raw = core_manager_at(&dir).provider().winws_executable();
         let bin_path = std::fs::canonicalize(&bin_path_raw)
             .map(strip_verbatim_prefix)
             .map_err(|e| format!("Failed to resolve {}: {}", bin_path_raw.display(), e))?;
@@ -1364,7 +1354,7 @@ try {{
             }
         }
     } else {
-        let bin_path = FlowsealProvider::new(&dir).winws_executable();
+        let bin_path = core_manager_at(&dir).provider().winws_executable();
         if !bin_path.exists() {
             return Err("winws.exe not found".to_string());
         }
@@ -1658,8 +1648,8 @@ fn import_backup_file() -> Result<bool, String> {
 #[tauri::command]
 async fn update_ipset_list() -> Result<String, String> {
     let dir = find_binaries_dir();
-    let provider = FlowsealProvider::new(&dir);
-    debug_assert_eq!(provider.id(), "flowseal");
+    let manager = core_manager_at(&dir);
+    let provider = manager.provider();
     let list_file = provider.paths().lists_dir().join("ipset-all.txt");
     let url = provider.ipset_url();
 
@@ -1804,9 +1794,10 @@ async fn download_and_install_update(
         .map_err(|e| format!("Failed to build http client: {}", e))?;
 
     // Fetch version from GitHub with fallback to SourceForge
-    let provider = FlowsealProvider::new(&dir);
+    let manager = core_manager_at(&dir);
+    let provider = manager.provider();
     let mut fetched_from_sf = false;
-    let mut sf_info: Option<SfReleaseInfo> = None;
+    let mut sf_info: Option<CoreRelease> = None;
 
     let latest_version = match client
         .get(provider.version_url())
@@ -1821,7 +1812,7 @@ async fn download_and_install_update(
                     trimmed
                 } else {
                     fetched_from_sf = true;
-                    let info = fetch_sf_release_info(&client).await?;
+                    let info = fetch_fallback_release_info(&client).await?;
                     let version = info.version.clone();
                     sf_info = Some(info);
                     version
@@ -1829,7 +1820,7 @@ async fn download_and_install_update(
             }
             Err(_) => {
                 fetched_from_sf = true;
-                let info = fetch_sf_release_info(&client).await?;
+                let info = fetch_fallback_release_info(&client).await?;
                 let version = info.version.clone();
                 sf_info = Some(info);
                 version
@@ -1837,7 +1828,7 @@ async fn download_and_install_update(
         },
         _ => {
             fetched_from_sf = true;
-            let info = fetch_sf_release_info(&client).await?;
+            let info = fetch_fallback_release_info(&client).await?;
             let version = info.version.clone();
             sf_info = Some(info);
             version
@@ -1887,7 +1878,7 @@ async fn download_and_install_update(
         // Ensure we have SF info loaded
         let info = match sf_info {
             Some(i) => i,
-            None => fetch_sf_release_info(&client).await?,
+            None => fetch_fallback_release_info(&client).await?,
         };
 
         // Try downloading from the direct SourceForge URL
@@ -1899,7 +1890,7 @@ async fn download_and_install_update(
             }
             _ => {
                 // Also try downloading from the generic latest URL user requested as fallback
-                let generic_url = provider.fallback_latest_url();
+                let generic_url = manager.fallback_latest_url();
                 match client.get(generic_url).send().await {
                     Ok(resp) if resp.status().is_success() => {
                         response = Some(resp);
@@ -1959,12 +1950,20 @@ async fn download_and_install_update(
     // Verify integrity of downloaded archive
     if downloaded_from_sf {
         if let Some(info) = sf_info {
+            let expected_md5 = match info.checksum {
+                Some(Checksum::Md5(value)) => value,
+                _ => {
+                    return Err(
+                        "Downloaded from SourceForge but MD5 metadata is missing".to_string()
+                    )
+                }
+            };
             let actual_md5 = md5_file(&zip_path)?;
-            if actual_md5 != info.md5sum.to_ascii_lowercase() {
+            if actual_md5 != expected_md5.to_ascii_lowercase() {
                 let _ = std::fs::remove_file(&zip_path);
                 return Err(format!(
                     "Checksum mismatch (MD5) for SourceForge download: expected {}, got {}",
-                    info.md5sum, actual_md5
+                    expected_md5, actual_md5
                 ));
             }
         } else {
@@ -1972,7 +1971,12 @@ async fn download_and_install_update(
         }
     } else {
         let asset_name = provider.archive_name(&latest_version);
-        let expected_sha256 = fetch_expected_sha256(&latest_version, &asset_name).await?;
+        let expected_checksum =
+            Checksum::Sha256(fetch_expected_sha256(&latest_version, &asset_name).await?);
+        let expected_sha256 = match expected_checksum {
+            Checksum::Sha256(value) => value,
+            Checksum::Md5(_) => unreachable!("GitHub releases require SHA-256"),
+        };
         let actual_sha256 = sha256_file(&zip_path)?;
         if actual_sha256 != expected_sha256 {
             let _ = std::fs::remove_file(&zip_path);
@@ -2806,7 +2810,11 @@ fn cancel_tests(state: State<'_, AppState>) {
             .output();
     }
     // Remove temp script if it still exists
-    let temp_script = find_binaries_dir().join("utils").join("test_zapret_ui.ps1");
+    let temp_script = core_manager()
+        .provider()
+        .paths()
+        .utils_dir()
+        .join("test_zapret_ui.ps1");
     let _ = std::fs::remove_file(&temp_script);
 }
 
@@ -2818,7 +2826,8 @@ async fn run_tests(
     test_mode: String,
 ) -> Result<Vec<TestResult>, String> {
     let dir = find_binaries_dir();
-    let ps_script = FlowsealProvider::new(&dir).test_script();
+    let manager = core_manager_at(&dir);
+    let ps_script = manager.provider().test_script();
 
     if !ps_script.exists() {
         return Err(
@@ -2854,7 +2863,11 @@ async fn run_tests(
             "    # UI Mode - using all configs",
         );
 
-    let temp_script = utils_dir.join("test_zapret_ui.ps1");
+    let temp_script = manager
+        .provider()
+        .paths()
+        .utils_dir()
+        .join("test_zapret_ui.ps1");
     std::fs::write(&temp_script, modified_content)
         .map_err(|e| format!("Failed to write temp script: {}", e))?;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2039,11 +2039,11 @@ mod temporary_cleanup_tests {
             let path = temp_parent.join(format!("{prefix}test-{}", std::process::id()));
             let _ = std::fs::remove_dir_all(&path);
             std::fs::create_dir(&path).unwrap();
-            let result: Result<(), &str> = (|| {
+            let result: Result<(), &str> = {
                 let _cleanup =
                     OwnedDirectoryCleanup::new(path.clone(), expected_parent.clone(), prefix);
                 Err("simulated failure")
-            })();
+            };
             assert!(result.is_err());
             assert!(!path.exists());
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,11 +31,12 @@ use std::os::windows::process::CommandExt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tauri_plugin_notification::NotificationExt;
 
+mod core;
+mod providers;
+use core::CoreProvider;
+use providers::{parse_fallback_release, FlowsealProvider};
+
 const CREATE_NO_WINDOW: u32 = 0x08000000;
-const GITHUB_VERSION_URL: &str =
-    "https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/main/.service/version.txt";
-const GITHUB_RELEASE_API: &str =
-    "https://api.github.com/repos/Flowseal/zapret-discord-youtube/releases/tags";
 const GITHUB_USER_AGENT: &str = "zapret-ui-updater";
 
 struct AppState {
@@ -104,11 +105,7 @@ fn is_safe_strategy_name(name: &str) -> bool {
     if name.is_empty() || name.len() > 128 {
         return false;
     }
-    if name.contains("..")
-        || name.contains('/')
-        || name.contains('\\')
-        || name.contains(':')
-    {
+    if name.contains("..") || name.contains('/') || name.contains('\\') || name.contains(':') {
         return false;
     }
     if name.starts_with('.')
@@ -120,10 +117,7 @@ fn is_safe_strategy_name(name: &str) -> bool {
     }
     name.chars().all(|c| {
         c.is_ascii_alphanumeric()
-            || matches!(
-                c,
-                ' ' | '(' | ')' | '[' | ']' | '.' | '_' | '-' | '+' | ','
-            )
+            || matches!(c, ' ' | '(' | ')' | '[' | ']' | '.' | '_' | '-' | '+' | ',')
     })
 }
 
@@ -168,8 +162,7 @@ fn powershell_path() -> PathBuf {
     {
         let system_root =
             std::env::var("SystemRoot").unwrap_or_else(|_| String::from(r"C:\Windows"));
-        PathBuf::from(system_root)
-            .join(r"System32\WindowsPowerShell\v1.0\powershell.exe")
+        PathBuf::from(system_root).join(r"System32\WindowsPowerShell\v1.0\powershell.exe")
     }
     #[cfg(not(windows))]
     {
@@ -228,10 +221,7 @@ fn resolve_list_path(filename: &str) -> Result<PathBuf, String> {
             .map_err(|e| format!("Failed to resolve {}: {}", file_path.display(), e))?;
         let canonical_file = strip_verbatim_prefix(canonical_file);
         if !canonical_file.starts_with(&canonical_parent) {
-            return Err(format!(
-                "List file {} escapes its directory",
-                filename
-            ));
+            return Err(format!("List file {} escapes its directory", filename));
         }
         Ok(canonical_file)
     } else {
@@ -287,9 +277,8 @@ fn extract_zip_safely(zip_path: &std::path::Path, dest: &std::path::Path) -> Res
         let out_path = canonical_dest.join(&rel);
 
         if entry.is_dir() {
-            std::fs::create_dir_all(&out_path).map_err(|e| {
-                format!("Failed to create dir {}: {}", out_path.display(), e)
-            })?;
+            std::fs::create_dir_all(&out_path)
+                .map_err(|e| format!("Failed to create dir {}: {}", out_path.display(), e))?;
             continue;
         }
         if let Some(parent) = out_path.parent() {
@@ -365,7 +354,7 @@ async fn fetch_expected_sha256(version: &str, asset_name: &str) -> Result<String
         return Err(format!("Invalid upstream version tag: {}", version));
     }
 
-    let url = format!("{}/{}", GITHUB_RELEASE_API, version);
+    let url = FlowsealProvider::new(find_binaries_dir()).release_api_url(version);
     let client = reqwest::Client::builder()
         .user_agent(GITHUB_USER_AGENT)
         .build()
@@ -417,67 +406,27 @@ async fn fetch_expected_sha256(version: &str, asset_name: &str) -> Result<String
     Ok(hex.to_ascii_lowercase())
 }
 
-#[derive(Clone, Debug)]
-pub struct SfReleaseInfo {
-    pub version: String,
-    pub download_url: String,
-    pub md5sum: String,
-}
+pub type SfReleaseInfo = core::FallbackRelease;
 
 pub async fn fetch_sf_release_info(client: &reqwest::Client) -> Result<SfReleaseInfo, String> {
-    let sf_url = "https://sourceforge.net/projects/zapret-discord-youtube.mirror/best_release.json";
+    let provider = FlowsealProvider::new(find_binaries_dir());
     let response = client
-        .get(sf_url)
+        .get(provider.fallback_metadata_url())
         .header("Cache-Control", "no-cache")
         .send()
         .await
         .map_err(|e| format!("Failed to send SourceForge request: {}", e))?;
-    
     if !response.status().is_success() {
-        return Err(format!("SourceForge returned status: {}", response.status()));
+        return Err(format!(
+            "SourceForge returned status: {}",
+            response.status()
+        ));
     }
-    
     let body: serde_json::Value = response
         .json()
         .await
         .map_err(|e| format!("Failed to parse SourceForge JSON: {}", e))?;
-
-    // Try to get from platform_releases.windows, otherwise release
-    let windows_release = body.get("platform_releases")
-        .and_then(|pr| pr.get("windows"));
-
-    let release_obj = windows_release.unwrap_or_else(|| {
-        body.get("release").unwrap_or(&serde_json::Value::Null)
-    });
-
-    if release_obj.is_null() {
-        return Err("No release information found in SourceForge JSON".to_string());
-    }
-
-    let filename = release_obj.get("filename")
-        .and_then(|f| f.as_str())
-        .ok_or_else(|| "Missing filename in SourceForge JSON".to_string())?;
-
-    let download_url = release_obj.get("url")
-        .and_then(|u| u.as_str())
-        .ok_or_else(|| "Missing url in SourceForge JSON".to_string())?;
-
-    let md5sum = release_obj.get("md5sum")
-        .and_then(|m| m.as_str())
-        .ok_or_else(|| "Missing md5sum in SourceForge JSON".to_string())?;
-
-    let parts: Vec<&str> = filename.split('/').filter(|s| !s.is_empty()).collect();
-    let version = if let Some(first_part) = parts.first() {
-        first_part.to_string()
-    } else {
-        return Err("Failed to parse version from SourceForge filename".to_string());
-    };
-
-    Ok(SfReleaseInfo {
-        version,
-        download_url: download_url.to_string(),
-        md5sum: md5sum.to_string(),
-    })
+    parse_fallback_release(&body)
 }
 
 /// Computes the MD5 digest of a file as a lowercase hex string.
@@ -641,31 +590,7 @@ fn elevate_if_needed() {
 }
 
 fn get_local_version() -> String {
-    let dir = find_binaries_dir();
-    let service_bat = dir.join("service.bat");
-    
-    if !service_bat.exists() {
-        return format!("Err: Not Found at {:?}", service_bat);
-    }
-
-    match std::fs::read_to_string(&service_bat) {
-        Ok(content) => {
-            for line in content.lines() {
-                let lowercase = line.to_lowercase();
-                if lowercase.contains("local_version=") {
-                    let parts: Vec<&str> = line.splitn(2, '=').collect();
-                    if parts.len() > 1 {
-                        let version = parts[1].trim().trim_matches('"');
-                        if !version.is_empty() {
-                            return version.to_string();
-                        }
-                    }
-                }
-            }
-            "Err: No Version String Found".to_string()
-        }
-        Err(e) => format!("Err: Read Failed ({})", e),
-    }
+    FlowsealProvider::new(find_binaries_dir()).local_version()
 }
 
 #[tauri::command]
@@ -684,10 +609,11 @@ async fn get_remote_core_version(
     custom_proxy: Option<String>,
 ) -> Result<String, String> {
     let mut client_builder = reqwest::Client::builder();
-    
+
     let use_proxy = use_proxy.unwrap_or(false);
     if use_proxy {
-        let proxy_url = custom_proxy.or_else(|| option_env!("ZAPRET_UPDATE_PROXY").map(|s| s.to_string()));
+        let proxy_url =
+            custom_proxy.or_else(|| option_env!("ZAPRET_UPDATE_PROXY").map(|s| s.to_string()));
         if let Some(proxy_url) = proxy_url {
             if let Ok(proxy) = reqwest::Proxy::all(&proxy_url) {
                 client_builder = client_builder.proxy(proxy);
@@ -696,9 +622,9 @@ async fn get_remote_core_version(
     }
 
     let client = client_builder.build().map_err(|e| e.to_string())?;
-    
+
     let response_res = client
-        .get("https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/main/.service/version.txt")
+        .get(FlowsealProvider::new(find_binaries_dir()).version_url())
         .send()
         .await;
 
@@ -716,13 +642,19 @@ async fn get_remote_core_version(
             if let Ok(info) = fetch_sf_release_info(&client).await {
                 return Ok(info.version);
             }
-            Err(format!("GitHub returned status {} and SourceForge fallback failed", status))
+            Err(format!(
+                "GitHub returned status {} and SourceForge fallback failed",
+                status
+            ))
         }
         Err(e) => {
             if let Ok(info) = fetch_sf_release_info(&client).await {
                 return Ok(info.version);
             }
-            Err(format!("Failed to connect to GitHub ({}) and SourceForge fallback failed", e))
+            Err(format!(
+                "Failed to connect to GitHub ({}) and SourceForge fallback failed",
+                e
+            ))
         }
     }
 }
@@ -739,94 +671,15 @@ fn get_ui_version_cmd() -> String {
 
 #[tauri::command]
 fn ensure_binaries_present() -> bool {
-    let bin_dir = find_binaries_dir();
-    // In production, binaries is a folder inside resources.
-    // In dev, it's next to src-tauri.
-    // find_binaries_dir already handles this.
-    bin_dir.exists() && bin_dir.join("service.bat").exists()
+    FlowsealProvider::new(find_binaries_dir()).is_installed()
 }
 
 fn parse_bat_args(strategy: &str) -> Result<String, String> {
     if !is_safe_strategy_name(strategy) {
         return Err(format!("Invalid strategy name: {}", strategy));
     }
-    let dir = find_binaries_dir();
-    let bat_path = dir.join(format!("{}.bat", strategy));
-    let content = std::fs::read_to_string(&bat_path)
-        .map_err(|e| format!("Не удалось прочитать {}.bat: {}", strategy, e))?;
-
-    // Читаем текущие значения фильтров для подстановки
     let filters = get_filters_status();
-    let game_filter_mode = filters.game_filter;
-
-    // Для disabled используем "12" (порт не используется)
-    let (gf, gftcp, gfudp) = match game_filter_mode.as_str() {
-        "all" => ("1024-65535", "1024-65535", "1024-65535"),
-        "tcp" => ("1024-65535", "1024-65535", "12"),
-        "udp" => ("1024-65535", "12", "1024-65535"),
-        _ => ("12", "12", "12"),
-    };
-
-    let bin_path = dir.join("bin").to_str().unwrap_or("").to_string() + "\\";
-    let lists_path = dir.join("lists").to_str().unwrap_or("").to_string() + "\\";
-    let root_path = dir.to_str().unwrap_or("").to_string() + "\\";
-
-    // Ищем строку с запуском winws.exe и собираем все строки продолжения (^)
-    let lines: Vec<&str> = content.lines().collect();
-    let mut found_idx: Option<usize> = None;
-    for (i, line) in lines.iter().enumerate() {
-        if line.to_lowercase().contains("winws.exe") {
-            found_idx = Some(i);
-            break;
-        }
-    }
-
-    let found_idx =
-        found_idx.ok_or_else(|| format!("Не найдена строка с winws.exe в {}.bat", strategy))?;
-
-    // Собираем полную команду: первая строка + все строки-продолжения (^)
-    let mut full_command = String::new();
-    for raw in lines.iter().skip(found_idx) {
-        let line = raw.trim();
-        if let Some(rest) = line.strip_suffix('^') {
-            full_command.push_str(rest);
-            full_command.push(' ');
-        } else {
-            full_command.push_str(line);
-            break;
-        }
-    }
-
-    // Извлекаем аргументы после winws.exe
-    let cmd_lower = full_command.to_lowercase();
-    let mut args = String::new();
-    if let Some(pos) = cmd_lower.find("winws.exe\"") {
-        args = full_command[pos + "winws.exe\"".len()..].to_string();
-    } else if let Some(pos) = cmd_lower.find("winws.exe ") {
-        args = full_command[pos + "winws.exe ".len()..].to_string();
-    }
-
-    // Подстановка переменных (эмуляция service.bat)
-    args = args.replace("%GameFilter%", gf);
-    args = args.replace("%GameFilterTCP%", gftcp);
-    args = args.replace("%GameFilterUDP%", gfudp);
-    args = args.replace("%BIN%", &bin_path);
-    args = args.replace("%LISTS%", &lists_path);
-
-    // Замена @ на абсолютный путь к корню binaries. Аргументы возвращаются
-    // без бэт-экранирования кавычек; экранирование для конкретного способа
-    // запуска (bat / sc / PowerShell) делается на вызывающей стороне.
-    let mut final_args = String::new();
-    for word in args.split_whitespace() {
-        let mut w = word.to_string();
-        if w.starts_with("\"@") {
-            w = format!("\"{}{}", root_path, &w[2..]);
-        }
-        final_args.push_str(&w);
-        final_args.push(' ');
-    }
-
-    Ok(final_args.trim().to_string())
+    FlowsealProvider::new(find_binaries_dir()).parse_strategy(strategy, &filters.game_filter)
 }
 
 /// Splits a command-line arguments string into separate arguments, respecting double quotes
@@ -1025,31 +878,7 @@ fn check_status_full() -> Result<String, String> {
 /// Список стратегий — имена .bat файлов из binaries/ (без service.bat).
 #[tauri::command]
 fn get_strategies() -> Result<Vec<String>, String> {
-    let dir = find_binaries_dir();
-    let entries = std::fs::read_dir(&dir)
-        .map_err(|e| format!("Failed to read binaries ({:?}): {}", dir, e))?;
-
-    let mut list: Vec<String> = entries
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.path()
-                .extension()
-                .and_then(|x| x.to_str())
-                .map(|x| x.eq_ignore_ascii_case("bat"))
-                .unwrap_or(false)
-        })
-        .filter_map(|e| {
-            e.path()
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .map(|s| s.to_string())
-        })
-        .filter(|name| name != "service")
-        .collect();
-
-    // Natural sort (Windows-style) so ALT2 comes before ALT11
-    list.sort_by(|a, b| natural_sort_compare(a, b));
-    Ok(list)
+    FlowsealProvider::new(find_binaries_dir()).strategies()
 }
 
 /// Compare strings using natural sort (numbers compared numerically)
@@ -1453,16 +1282,10 @@ fn start_zapret(
         // the registry. That way the service points at the *real* executable
         // under `binaries/bin/`, not at a symlink that could later be
         // redirected to an attacker-controlled binary.
-        let bin_path_raw = dir.join("bin").join("winws.exe");
+        let bin_path_raw = FlowsealProvider::new(&dir).winws_executable();
         let bin_path = std::fs::canonicalize(&bin_path_raw)
             .map(strip_verbatim_prefix)
-            .map_err(|e| {
-                format!(
-                    "Failed to resolve {}: {}",
-                    bin_path_raw.display(),
-                    e
-                )
-            })?;
+            .map_err(|e| format!("Failed to resolve {}: {}", bin_path_raw.display(), e))?;
         if !bin_path.starts_with(&dir) {
             return Err(format!(
                 "winws.exe resolves outside binaries dir: {}",
@@ -1541,7 +1364,7 @@ try {{
             }
         }
     } else {
-        let bin_path = dir.join("bin").join("winws.exe");
+        let bin_path = FlowsealProvider::new(&dir).winws_executable();
         if !bin_path.exists() {
             return Err("winws.exe not found".to_string());
         }
@@ -1759,8 +1582,7 @@ fn save_user_list_to_file(filename: String) -> Result<bool, String> {
         .save_file();
 
     if let Some(path) = file_path {
-        std::fs::write(&path, content)
-            .map_err(|e| format!("Не удалось сохранить файл: {}", e))?;
+        std::fs::write(&path, content).map_err(|e| format!("Не удалось сохранить файл: {}", e))?;
         Ok(true)
     } else {
         Ok(false)
@@ -1836,8 +1658,10 @@ fn import_backup_file() -> Result<bool, String> {
 #[tauri::command]
 async fn update_ipset_list() -> Result<String, String> {
     let dir = find_binaries_dir();
-    let list_file = dir.join("lists").join("ipset-all.txt");
-    let url = "https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/refs/heads/main/.service/ipset-service.txt";
+    let provider = FlowsealProvider::new(&dir);
+    debug_assert_eq!(provider.id(), "flowseal");
+    let list_file = provider.paths().lists_dir().join("ipset-all.txt");
+    let url = provider.ipset_url();
 
     // Check if curl exists in System32
     let curl_path = std::path::Path::new(r"C:\Windows\System32\curl.exe");
@@ -1927,8 +1751,6 @@ fn is_ip_or_cidr(s: &str) -> bool {
     }
 }
 
-
-
 #[tauri::command]
 async fn download_and_install_update(
     window: tauri::Window,
@@ -1969,35 +1791,35 @@ async fn download_and_install_update(
     let mut client_builder = reqwest::Client::builder();
     let use_proxy = use_proxy.unwrap_or(false);
     if use_proxy {
-        let proxy_url = custom_proxy.or_else(|| option_env!("ZAPRET_UPDATE_PROXY").map(|s| s.to_string()));
+        let proxy_url =
+            custom_proxy.or_else(|| option_env!("ZAPRET_UPDATE_PROXY").map(|s| s.to_string()));
         if let Some(proxy_url) = proxy_url {
             if let Ok(proxy) = reqwest::Proxy::all(&proxy_url) {
                 client_builder = client_builder.proxy(proxy);
             }
         }
     }
-    let client = client_builder.build().map_err(|e| format!("Failed to build http client: {}", e))?;
+    let client = client_builder
+        .build()
+        .map_err(|e| format!("Failed to build http client: {}", e))?;
 
     // Fetch version from GitHub with fallback to SourceForge
+    let provider = FlowsealProvider::new(&dir);
     let mut fetched_from_sf = false;
     let mut sf_info: Option<SfReleaseInfo> = None;
 
-    let latest_version = match client.get(GITHUB_VERSION_URL).header("Cache-Control", "no-cache").send().await {
-        Ok(resp) if resp.status().is_success() => {
-            match resp.text().await {
-                Ok(text) => {
-                    let trimmed = text.trim().to_string();
-                    if !trimmed.is_empty() && !trimmed.contains("Not Found") {
-                        trimmed
-                    } else {
-                        fetched_from_sf = true;
-                        let info = fetch_sf_release_info(&client).await?;
-                        let version = info.version.clone();
-                        sf_info = Some(info);
-                        version
-                    }
-                }
-                Err(_) => {
+    let latest_version = match client
+        .get(provider.version_url())
+        .header("Cache-Control", "no-cache")
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => match resp.text().await {
+            Ok(text) => {
+                let trimmed = text.trim().to_string();
+                if !trimmed.is_empty() && !trimmed.contains("Not Found") {
+                    trimmed
+                } else {
                     fetched_from_sf = true;
                     let info = fetch_sf_release_info(&client).await?;
                     let version = info.version.clone();
@@ -2005,7 +1827,14 @@ async fn download_and_install_update(
                     version
                 }
             }
-        }
+            Err(_) => {
+                fetched_from_sf = true;
+                let info = fetch_sf_release_info(&client).await?;
+                let version = info.version.clone();
+                sf_info = Some(info);
+                version
+            }
+        },
         _ => {
             fetched_from_sf = true;
             let info = fetch_sf_release_info(&client).await?;
@@ -2045,7 +1874,7 @@ async fn download_and_install_update(
     let mut downloaded_from_sf = false;
 
     if !fetched_from_sf {
-        let github_url = format!("https://github.com/Flowseal/zapret-discord-youtube/releases/download/{}/zapret-discord-youtube-{}.zip", latest_version, latest_version);
+        let github_url = provider.release_download_url(&latest_version);
         if let Ok(resp) = client.get(&github_url).send().await {
             if resp.status().is_success() {
                 response = Some(resp);
@@ -2070,7 +1899,7 @@ async fn download_and_install_update(
             }
             _ => {
                 // Also try downloading from the generic latest URL user requested as fallback
-                let generic_url = "https://sourceforge.net/projects/zapret-discord-youtube.mirror/files/latest/download";
+                let generic_url = provider.fallback_latest_url();
                 match client.get(generic_url).send().await {
                     Ok(resp) if resp.status().is_success() => {
                         response = Some(resp);
@@ -2079,11 +1908,17 @@ async fn download_and_install_update(
                     }
                     Ok(resp) => {
                         done_flag.store(true, Ordering::Relaxed);
-                        return Err(format!("SourceForge download failed with status: {}", resp.status()));
+                        return Err(format!(
+                            "SourceForge download failed with status: {}",
+                            resp.status()
+                        ));
                     }
                     Err(e) => {
                         done_flag.store(true, Ordering::Relaxed);
-                        return Err(format!("Failed to download from both GitHub and SourceForge. SF error: {}", e));
+                        return Err(format!(
+                            "Failed to download from both GitHub and SourceForge. SF error: {}",
+                            e
+                        ));
                     }
                 }
             }
@@ -2136,7 +1971,7 @@ async fn download_and_install_update(
             return Err("Downloaded from SourceForge but release metadata is missing".to_string());
         }
     } else {
-        let asset_name = format!("zapret-discord-youtube-{}.zip", latest_version);
+        let asset_name = provider.archive_name(&latest_version);
         let expected_sha256 = fetch_expected_sha256(&latest_version, &asset_name).await?;
         let actual_sha256 = sha256_file(&zip_path)?;
         if actual_sha256 != expected_sha256 {
@@ -2199,7 +2034,8 @@ fn copy_dir_contents(src: &std::path::Path, dst: &std::path::Path) -> Result<(),
         let dest_path = dst.join(&file_name);
 
         if path.is_dir() {
-            std::fs::create_dir_all(&dest_path).map_err(|e| format!("Failed to create directory {:?}: {}", dest_path, e))?;
+            std::fs::create_dir_all(&dest_path)
+                .map_err(|e| format!("Failed to create directory {:?}: {}", dest_path, e))?;
             copy_dir_contents(&path, &dest_path)?;
         } else {
             if let Err(e) = std::fs::copy(&path, &dest_path) {
@@ -2207,14 +2043,20 @@ fn copy_dir_contents(src: &std::path::Path, dst: &std::path::Path) -> Result<(),
                 let mut old_path = dest_path.clone();
                 let new_name = format!("{}.old", file_name.to_str().unwrap_or("locked"));
                 old_path.set_file_name(new_name);
-                
+
                 if std::fs::rename(&dest_path, &old_path).is_err() {
-                    return Err(format!("Failed to copy file {:?} to {:?}: {}", path, dest_path, e));
+                    return Err(format!(
+                        "Failed to copy file {:?} to {:?}: {}",
+                        path, dest_path, e
+                    ));
                 }
 
                 // Attempt copy again after rename
                 std::fs::copy(&path, &dest_path).map_err(|e2| {
-                    format!("Failed to copy file {:?} to {:?} after renaming: {}", path, dest_path, e2)
+                    format!(
+                        "Failed to copy file {:?} to {:?} after renaming: {}",
+                        path, dest_path, e2
+                    )
                 })?;
             }
         }
@@ -2743,7 +2585,10 @@ async fn check_site(domain: String, state: State<'_, AppState>) -> Result<SiteCh
         if let Ok(socket_addr) = format!("{}:443", ip).parse::<std::net::SocketAddr>() {
             let start = std::time::Instant::now();
             let connect_timeout = std::time::Duration::from_secs(3);
-            if let Ok(Ok(_)) = tokio::time::timeout(connect_timeout, tokio::net::TcpStream::connect(socket_addr)).await {
+            if let Ok(Ok(_)) =
+                tokio::time::timeout(connect_timeout, tokio::net::TcpStream::connect(socket_addr))
+                    .await
+            {
                 ping_ms = Some(start.elapsed().as_millis() as u32);
             }
         }
@@ -2926,8 +2771,7 @@ fn test_results_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
         .path()
         .app_data_dir()
         .map_err(|e| format!("Failed to resolve app data dir: {}", e))?;
-    std::fs::create_dir_all(&dir)
-        .map_err(|e| format!("Failed to create app data dir: {}", e))?;
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create app data dir: {}", e))?;
     Ok(dir.join("test_results.json"))
 }
 
@@ -2936,8 +2780,7 @@ fn save_test_results(app: tauri::AppHandle, payload: SavedTestResults) -> Result
     let path = test_results_path(&app)?;
     let json = serde_json::to_string_pretty(&payload)
         .map_err(|e| format!("Failed to serialize test results: {}", e))?;
-    std::fs::write(&path, json)
-        .map_err(|e| format!("Failed to write test results: {}", e))?;
+    std::fs::write(&path, json).map_err(|e| format!("Failed to write test results: {}", e))?;
     Ok(())
 }
 
@@ -2975,8 +2818,7 @@ async fn run_tests(
     test_mode: String,
 ) -> Result<Vec<TestResult>, String> {
     let dir = find_binaries_dir();
-    let utils_dir = dir.join("utils");
-    let ps_script = utils_dir.join("test zapret.ps1");
+    let ps_script = FlowsealProvider::new(&dir).test_script();
 
     if !ps_script.exists() {
         return Err(
@@ -3146,10 +2988,7 @@ async fn run_tests(
 
         // Structured event: "Best config: X"
         if let Some(rest) = line.strip_prefix("Best config:") {
-            let _ = app.emit(
-                "test-best",
-                serde_json::json!({ "config": rest.trim() }),
-            );
+            let _ = app.emit("test-best", serde_json::json!({ "config": rest.trim() }));
         }
 
         let _ = app.emit(
@@ -3237,7 +3076,9 @@ async fn run_tests(
 /// единицы измерения (например `AvgPing: 45 ms` → 45) и запятые в конце
 /// (`Ping OK: 5,` → 5).
 fn extract_number(text: &str, prefix: &str) -> i32 {
-    let Some(pos) = text.find(prefix) else { return 0 };
+    let Some(pos) = text.find(prefix) else {
+        return 0;
+    };
     let after = &text[pos + prefix.len()..];
     let mut started = false;
     let mut digits = String::new();
@@ -3328,7 +3169,6 @@ fn exit_app(app: tauri::AppHandle, state: State<'_, AppState>) {
     app.exit(0);
 }
 
-
 // ─── Entry point ──────────────────────────────────────────────────────────────
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -3345,18 +3185,17 @@ pub fn run() {
             Some(vec!["--autostart"]),
         ))
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
-            let _ = app.get_webview_window("main")
-                .map(|w| {
-                    let _ = w.show();
-                    let _ = w.unminimize();
-                    let _ = w.set_focus();
+            let _ = app.get_webview_window("main").map(|w| {
+                let _ = w.show();
+                let _ = w.unminimize();
+                let _ = w.set_focus();
 
-                    let state = app.state::<AppState>();
-                    let tray_opt = state.tray_handle.lock_unpoisoned().clone();
-                    if let Some(tray) = tray_opt {
-                        let _ = tray.set_visible(false);
-                    }
-                });
+                let state = app.state::<AppState>();
+                let tray_opt = state.tray_handle.lock_unpoisoned().clone();
+                if let Some(tray) = tray_opt {
+                    let _ = tray.set_visible(false);
+                }
+            });
         }))
         .manage(AppState {
             active_strategy: Mutex::new(None),
@@ -3461,7 +3300,8 @@ pub fn run() {
                                     .or(status.strategy)
                                     .or_else(|| available.first().cloned());
                                 if let Some(s) = strategy {
-                                    let _ = start_zapret(app.clone(), s, "service".to_string(), state);
+                                    let _ =
+                                        start_zapret(app.clone(), s, "service".to_string(), state);
                                 }
                             }
                             refresh_tray_menu(app);
@@ -3469,8 +3309,12 @@ pub fn run() {
                         id if id.starts_with("strat_") => {
                             let strategy = &id[6..];
                             let state = app.state::<AppState>();
-                            let _ =
-                                start_zapret(app.clone(), strategy.to_string(), "service".to_string(), state);
+                            let _ = start_zapret(
+                                app.clone(),
+                                strategy.to_string(),
+                                "service".to_string(),
+                                state,
+                            );
                             refresh_tray_menu(app);
                         }
                         _ => {}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -592,7 +592,8 @@ async fn get_core_update_info(
     custom_proxy: Option<String>,
 ) -> Result<CoreUpdateInfo, String> {
     let stable = get_remote_core_version(use_proxy, custom_proxy).await?;
-    let provider = core_manager().provider();
+    let manager = core_manager();
+    let provider = manager.provider();
     let current = provider.is_installed().then(|| provider.local_version());
     let status = current
         .as_deref()
@@ -1805,7 +1806,11 @@ async fn download_and_install_update(
             continue;
         }
         let actual = sha256_file(&zip_path)?;
-        if actual == artifact.checksum.value {
+        let expected = match &artifact.checksum {
+            Checksum::Sha256(value) => value,
+            Checksum::Md5(_) => continue,
+        };
+        if actual == *expected {
             selected = Some((artifact.url.clone(), Checksum::Sha256(actual)));
             break;
         }

--- a/src-tauri/src/providers/flowseal.rs
+++ b/src-tauri/src/providers/flowseal.rs
@@ -1,15 +1,7 @@
 use std::{cmp::Ordering, path::PathBuf};
 
-use crate::core::{Checksum, CorePaths, CoreProvider, CoreRelease};
+use crate::core::{CorePaths, CoreProvider};
 
-const VERSION_URL: &str =
-    "https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/main/.service/version.txt";
-const RELEASE_API: &str =
-    "https://api.github.com/repos/Flowseal/zapret-discord-youtube/releases/tags";
-const FALLBACK_METADATA_URL: &str =
-    "https://sourceforge.net/projects/zapret-discord-youtube.mirror/best_release.json";
-const FALLBACK_LATEST_URL: &str =
-    "https://sourceforge.net/projects/zapret-discord-youtube.mirror/files/latest/download";
 const IPSET_URL: &str = "https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/refs/heads/main/.service/ipset-service.txt";
 
 pub struct FlowsealProvider {
@@ -36,33 +28,6 @@ impl FlowsealProvider {
             })
             .filter(|version| !version.is_empty())
             .ok_or_else(|| "Err: No Version String Found".to_string())
-    }
-
-    pub async fn fetch_fallback_release(
-        &self,
-        client: &reqwest::Client,
-    ) -> Result<CoreRelease, String> {
-        let response = client
-            .get(FALLBACK_METADATA_URL)
-            .header("Cache-Control", "no-cache")
-            .send()
-            .await
-            .map_err(|e| format!("Failed to send SourceForge request: {e}"))?;
-        if !response.status().is_success() {
-            return Err(format!(
-                "SourceForge returned status: {}",
-                response.status()
-            ));
-        }
-        let body = response
-            .json()
-            .await
-            .map_err(|e| format!("Failed to parse SourceForge JSON: {e}"))?;
-        parse_fallback_release(&body)
-    }
-
-    pub fn fallback_latest_url(&self) -> &'static str {
-        FALLBACK_LATEST_URL
     }
 
     fn parse_strategy_content(
@@ -129,21 +94,6 @@ impl CoreProvider for FlowsealProvider {
     }
     fn paths(&self) -> &CorePaths {
         &self.paths
-    }
-    fn version_url(&self) -> &'static str {
-        VERSION_URL
-    }
-    fn release_api_url(&self, version: &str) -> String {
-        format!("{RELEASE_API}/{version}")
-    }
-    fn archive_name(&self, version: &str) -> String {
-        format!("zapret-discord-youtube-{version}.zip")
-    }
-    fn release_download_url(&self, version: &str) -> String {
-        format!(
-            "https://github.com/Flowseal/zapret-discord-youtube/releases/download/{version}/{}",
-            self.archive_name(version)
-        )
     }
     fn ipset_url(&self) -> &'static str {
         IPSET_URL
@@ -241,36 +191,6 @@ impl CoreProvider for FlowsealProvider {
     }
 }
 
-pub fn parse_fallback_release(body: &serde_json::Value) -> Result<CoreRelease, String> {
-    let release = body
-        .pointer("/platform_releases/windows")
-        .or_else(|| body.get("release"))
-        .ok_or_else(|| "No release information found in SourceForge JSON".to_string())?;
-    let filename = release
-        .get("filename")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| "Missing filename in SourceForge JSON".to_string())?;
-    Ok(CoreRelease {
-        version: filename
-            .split('/')
-            .find(|s| !s.is_empty())
-            .ok_or_else(|| "Failed to parse version from SourceForge filename".to_string())?
-            .to_owned(),
-        download_url: release
-            .get("url")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| "Missing url in SourceForge JSON".to_string())?
-            .to_owned(),
-        checksum: Some(Checksum::Md5(
-            release
-                .get("md5sum")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| "Missing md5sum in SourceForge JSON".to_string())?
-                .to_owned(),
-        )),
-    })
-}
-
 fn natural_compare(a: &str, b: &str) -> Ordering {
     let (mut a, mut b) = (a.chars().peekable(), b.chars().peekable());
     loop {
@@ -306,27 +226,6 @@ mod tests {
         let _ = std::fs::remove_dir_all(&p);
         std::fs::create_dir_all(&p).expect("temp");
         p
-    }
-    #[test]
-    fn release_urls_and_names() {
-        let p = FlowsealProvider::new("x");
-        assert_eq!(p.archive_name("1.2"), "zapret-discord-youtube-1.2.zip");
-        assert!(p
-            .release_download_url("1.2")
-            .ends_with("/1.2/zapret-discord-youtube-1.2.zip"));
-    }
-    #[test]
-    fn parses_sourceforge_release_with_md5() {
-        let body = serde_json::json!({
-            "platform_releases": { "windows": {
-                "filename": "/v1/archive.zip",
-                "url": "https://example.invalid/archive.zip",
-                "md5sum": "abcdef"
-            }}
-        });
-        let release = parse_fallback_release(&body).expect("fallback release");
-        assert_eq!(release.version, "v1");
-        assert_eq!(release.checksum, Some(Checksum::Md5("abcdef".to_string())));
     }
 
     #[test]

--- a/src-tauri/src/providers/flowseal.rs
+++ b/src-tauri/src/providers/flowseal.rs
@@ -124,6 +124,9 @@ impl FlowsealProvider {
 }
 
 impl CoreProvider for FlowsealProvider {
+    fn provider_name(&self) -> &'static str {
+        "flowseal"
+    }
     fn paths(&self) -> &CorePaths {
         &self.paths
     }
@@ -192,6 +195,49 @@ impl CoreProvider for FlowsealProvider {
         let content = std::fs::read_to_string(self.paths.root().join(format!("{strategy}.bat")))
             .map_err(|e| format!("Не удалось прочитать {strategy}.bat: {e}"))?;
         self.parse_strategy_content(&content, strategy, game_filter)
+    }
+    fn validate_installation(&self) -> Result<(String, usize), String> {
+        let root = self.paths.root();
+        if !root.is_dir() {
+            return Err(format!(
+                "Unexpected archive structure: {} is not a directory",
+                root.display()
+            ));
+        }
+        for path in [
+            self.service_script(),
+            self.winws_executable(),
+            self.test_script(),
+        ] {
+            if !path.is_file() {
+                return Err(format!("Missing required file: {}", path.display()));
+            }
+        }
+        for path in [self.paths.lists_dir(), self.paths.utils_dir()] {
+            if !path.is_dir() {
+                return Err(format!("Missing required directory: {}", path.display()));
+            }
+        }
+        let windivert = self.paths.bin_dir().join("WinDivert.dll");
+        let windivert64 = self.paths.bin_dir().join("WinDivert64.sys");
+        for path in [windivert, windivert64] {
+            if !path.is_file() {
+                return Err(format!("Missing required file: {}", path.display()));
+            }
+        }
+        let strategies = self.strategies()?;
+        if strategies.is_empty() {
+            return Err("No Flowseal strategies found".to_string());
+        }
+        for strategy in &strategies {
+            self.parse_strategy(strategy, "all")
+                .map_err(|e| format!("Strategy {strategy} cannot be parsed: {e}"))?;
+        }
+        let version = self.local_version();
+        if version.starts_with("Err:") {
+            return Err(format!("Cannot determine Flowseal version: {version}"));
+        }
+        Ok((version, strategies.len()))
     }
 }
 

--- a/src-tauri/src/providers/flowseal.rs
+++ b/src-tauri/src/providers/flowseal.rs
@@ -1,0 +1,279 @@
+use std::{cmp::Ordering, path::PathBuf};
+
+use crate::core::{CorePaths, CoreProvider, FallbackRelease};
+
+const VERSION_URL: &str =
+    "https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/main/.service/version.txt";
+const RELEASE_API: &str =
+    "https://api.github.com/repos/Flowseal/zapret-discord-youtube/releases/tags";
+const FALLBACK_METADATA_URL: &str =
+    "https://sourceforge.net/projects/zapret-discord-youtube.mirror/best_release.json";
+const FALLBACK_LATEST_URL: &str =
+    "https://sourceforge.net/projects/zapret-discord-youtube.mirror/files/latest/download";
+const IPSET_URL: &str = "https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/refs/heads/main/.service/ipset-service.txt";
+
+pub struct FlowsealProvider {
+    paths: CorePaths,
+}
+
+impl FlowsealProvider {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            paths: CorePaths::new(root),
+        }
+    }
+
+    pub fn parse_local_version(content: &str) -> Result<String, String> {
+        content
+            .lines()
+            .find_map(|line| {
+                if line.to_ascii_lowercase().contains("local_version=") {
+                    line.split_once('=')
+                        .map(|(_, value)| value.trim().trim_matches('"').to_owned())
+                } else {
+                    None
+                }
+            })
+            .filter(|version| !version.is_empty())
+            .ok_or_else(|| "Err: No Version String Found".to_string())
+    }
+
+    fn parse_strategy_content(
+        &self,
+        content: &str,
+        strategy: &str,
+        game_filter: &str,
+    ) -> Result<String, String> {
+        let (gf, gftcp, gfudp) = match game_filter {
+            "all" => ("1024-65535", "1024-65535", "1024-65535"),
+            "tcp" => ("1024-65535", "1024-65535", "12"),
+            "udp" => ("1024-65535", "12", "1024-65535"),
+            _ => ("12", "12", "12"),
+        };
+        let lines: Vec<_> = content.lines().collect();
+        let start = lines
+            .iter()
+            .position(|line| line.to_ascii_lowercase().contains("winws.exe"))
+            .ok_or_else(|| format!("Не найдена строка с winws.exe в {}.bat", strategy))?;
+        let mut command = String::new();
+        for raw in &lines[start..] {
+            let line = raw.trim();
+            if let Some(rest) = line.strip_suffix('^') {
+                command.push_str(rest);
+                command.push(' ');
+            } else {
+                command.push_str(line);
+                break;
+            }
+        }
+        let lower = command.to_ascii_lowercase();
+        let offset = lower
+            .find("winws.exe\"")
+            .map(|p| p + 10)
+            .or_else(|| lower.find("winws.exe ").map(|p| p + 10))
+            .ok_or_else(|| format!("Не найдена строка с winws.exe в {}.bat", strategy))?;
+        let suffix = std::path::MAIN_SEPARATOR.to_string();
+        let bin = self.paths.bin_dir().to_string_lossy().to_string() + &suffix;
+        let lists = self.paths.lists_dir().to_string_lossy().to_string() + &suffix;
+        let root = self.paths.root().to_string_lossy().to_string() + &suffix;
+        let args = command[offset..]
+            .replace("%GameFilter%", gf)
+            .replace("%GameFilterTCP%", gftcp)
+            .replace("%GameFilterUDP%", gfudp)
+            .replace("%BIN%", &bin)
+            .replace("%LISTS%", &lists);
+        Ok(args
+            .split_whitespace()
+            .map(|word| {
+                if let Some(rest) = word.strip_prefix("\"@") {
+                    format!("\"{}{}", root, rest)
+                } else {
+                    word.to_owned()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" "))
+    }
+}
+
+impl CoreProvider for FlowsealProvider {
+    fn id(&self) -> &'static str {
+        "flowseal"
+    }
+    fn paths(&self) -> &CorePaths {
+        &self.paths
+    }
+    fn version_url(&self) -> &'static str {
+        VERSION_URL
+    }
+    fn release_api_url(&self, version: &str) -> String {
+        format!("{RELEASE_API}/{version}")
+    }
+    fn archive_name(&self, version: &str) -> String {
+        format!("zapret-discord-youtube-{version}.zip")
+    }
+    fn release_download_url(&self, version: &str) -> String {
+        format!(
+            "https://github.com/Flowseal/zapret-discord-youtube/releases/download/{version}/{}",
+            self.archive_name(version)
+        )
+    }
+    fn fallback_metadata_url(&self) -> &'static str {
+        FALLBACK_METADATA_URL
+    }
+    fn fallback_latest_url(&self) -> &'static str {
+        FALLBACK_LATEST_URL
+    }
+    fn ipset_url(&self) -> &'static str {
+        IPSET_URL
+    }
+    fn service_script(&self) -> PathBuf {
+        self.paths.root().join("service.bat")
+    }
+    fn test_script(&self) -> PathBuf {
+        self.paths.utils_dir().join("test zapret.ps1")
+    }
+    fn winws_executable(&self) -> PathBuf {
+        self.paths.bin_dir().join("winws.exe")
+    }
+    fn local_version(&self) -> String {
+        let path = self.service_script();
+        if !path.exists() {
+            return format!("Err: Not Found at {:?}", path);
+        }
+        std::fs::read_to_string(&path)
+            .map_err(|e| format!("Err: Read Failed ({e})"))
+            .and_then(|content| Self::parse_local_version(&content))
+            .unwrap_or_else(|e| e)
+    }
+    fn is_installed(&self) -> bool {
+        self.paths.root().exists() && self.service_script().exists()
+    }
+    fn strategies(&self) -> Result<Vec<String>, String> {
+        let mut result = std::fs::read_dir(self.paths.root())
+            .map_err(|e| format!("Failed to read binaries ({:?}): {}", self.paths.root(), e))?
+            .filter_map(Result::ok)
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .and_then(|x| x.to_str())
+                    .is_some_and(|x| x.eq_ignore_ascii_case("bat"))
+            })
+            .filter_map(|e| {
+                e.path()
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(str::to_owned)
+            })
+            .filter(|name| !name.eq_ignore_ascii_case("service"))
+            .collect::<Vec<_>>();
+        result.sort_by(|a, b| natural_compare(a, b));
+        Ok(result)
+    }
+    fn parse_strategy(&self, strategy: &str, game_filter: &str) -> Result<String, String> {
+        let content = std::fs::read_to_string(self.paths.root().join(format!("{strategy}.bat")))
+            .map_err(|e| format!("Не удалось прочитать {strategy}.bat: {e}"))?;
+        self.parse_strategy_content(&content, strategy, game_filter)
+    }
+}
+
+pub fn parse_fallback_release(body: &serde_json::Value) -> Result<FallbackRelease, String> {
+    let release = body
+        .pointer("/platform_releases/windows")
+        .or_else(|| body.get("release"))
+        .ok_or_else(|| "No release information found in SourceForge JSON".to_string())?;
+    let filename = release
+        .get("filename")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "Missing filename in SourceForge JSON".to_string())?;
+    Ok(FallbackRelease {
+        version: filename
+            .split('/')
+            .find(|s| !s.is_empty())
+            .ok_or_else(|| "Failed to parse version from SourceForge filename".to_string())?
+            .to_owned(),
+        download_url: release
+            .get("url")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "Missing url in SourceForge JSON".to_string())?
+            .to_owned(),
+        md5sum: release
+            .get("md5sum")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "Missing md5sum in SourceForge JSON".to_string())?
+            .to_owned(),
+    })
+}
+
+fn natural_compare(a: &str, b: &str) -> Ordering {
+    let (mut a, mut b) = (a.chars().peekable(), b.chars().peekable());
+    loop {
+        match (a.peek(), b.peek()) {
+            (Some(x), Some(y)) if x.is_ascii_digit() && y.is_ascii_digit() => {
+                let an: String = std::iter::from_fn(|| a.next_if(|c| c.is_ascii_digit())).collect();
+                let bn: String = std::iter::from_fn(|| b.next_if(|c| c.is_ascii_digit())).collect();
+                let ord = an
+                    .trim_start_matches('0')
+                    .len()
+                    .cmp(&bn.trim_start_matches('0').len())
+                    .then_with(|| an.cmp(&bn));
+                if ord != Ordering::Equal {
+                    return ord;
+                }
+            }
+            (Some(_), Some(_)) => {
+                let ord = a.next().cmp(&b.next());
+                if ord != Ordering::Equal {
+                    return ord;
+                }
+            }
+            _ => return a.next().cmp(&b.next()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn temp() -> PathBuf {
+        let p = std::env::temp_dir().join(format!("zapret-provider-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).expect("temp");
+        p
+    }
+    #[test]
+    fn release_urls_and_names() {
+        let p = FlowsealProvider::new("x");
+        assert_eq!(p.archive_name("1.2"), "zapret-discord-youtube-1.2.zip");
+        assert!(p
+            .release_download_url("1.2")
+            .ends_with("/1.2/zapret-discord-youtube-1.2.zip"));
+    }
+    #[test]
+    fn parses_local_version() {
+        assert_eq!(
+            FlowsealProvider::parse_local_version("set LOCAL_VERSION=1.2\n").as_deref(),
+            Ok("1.2")
+        );
+        assert!(FlowsealProvider::parse_local_version("echo no").is_err());
+        assert!(FlowsealProvider::parse_local_version("local_version=\"\"").is_err());
+    }
+    #[test]
+    fn finds_and_naturally_sorts_strategies() {
+        let root = temp();
+        for n in ["ALT11.bat", "service.bat", "ALT2.bat"] {
+            std::fs::write(root.join(n), "").expect("write");
+        }
+        let p = FlowsealProvider::new(&root);
+        assert_eq!(p.strategies().expect("strategies"), ["ALT2", "ALT11"]);
+        let _ = std::fs::remove_dir_all(root);
+    }
+    #[test]
+    fn parses_multiline_strategy_and_variables() {
+        let p = FlowsealProvider::new("core");
+        let args=p.parse_strategy_content("\"%BIN%winws.exe\" --filter-tcp=%GameFilterTCP% ^\n --hostlist=\"%LISTS%list.txt\" --fake=\"@bin\\fake.bin\"", "ALT", "tcp").expect("parse");
+        assert!(args.contains("1024-65535"));
+        assert!(args.contains("core"));
+        assert!(p.parse_strategy_content("echo no", "ALT", "all").is_err());
+    }
+}

--- a/src-tauri/src/providers/flowseal.rs
+++ b/src-tauri/src/providers/flowseal.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, path::PathBuf};
 
-use crate::core::{CorePaths, CoreProvider, FallbackRelease};
+use crate::core::{Checksum, CorePaths, CoreProvider, CoreRelease};
 
 const VERSION_URL: &str =
     "https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/main/.service/version.txt";
@@ -36,6 +36,33 @@ impl FlowsealProvider {
             })
             .filter(|version| !version.is_empty())
             .ok_or_else(|| "Err: No Version String Found".to_string())
+    }
+
+    pub async fn fetch_fallback_release(
+        &self,
+        client: &reqwest::Client,
+    ) -> Result<CoreRelease, String> {
+        let response = client
+            .get(FALLBACK_METADATA_URL)
+            .header("Cache-Control", "no-cache")
+            .send()
+            .await
+            .map_err(|e| format!("Failed to send SourceForge request: {e}"))?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "SourceForge returned status: {}",
+                response.status()
+            ));
+        }
+        let body = response
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse SourceForge JSON: {e}"))?;
+        parse_fallback_release(&body)
+    }
+
+    pub fn fallback_latest_url(&self) -> &'static str {
+        FALLBACK_LATEST_URL
     }
 
     fn parse_strategy_content(
@@ -97,9 +124,6 @@ impl FlowsealProvider {
 }
 
 impl CoreProvider for FlowsealProvider {
-    fn id(&self) -> &'static str {
-        "flowseal"
-    }
     fn paths(&self) -> &CorePaths {
         &self.paths
     }
@@ -117,12 +141,6 @@ impl CoreProvider for FlowsealProvider {
             "https://github.com/Flowseal/zapret-discord-youtube/releases/download/{version}/{}",
             self.archive_name(version)
         )
-    }
-    fn fallback_metadata_url(&self) -> &'static str {
-        FALLBACK_METADATA_URL
-    }
-    fn fallback_latest_url(&self) -> &'static str {
-        FALLBACK_LATEST_URL
     }
     fn ipset_url(&self) -> &'static str {
         IPSET_URL
@@ -177,7 +195,7 @@ impl CoreProvider for FlowsealProvider {
     }
 }
 
-pub fn parse_fallback_release(body: &serde_json::Value) -> Result<FallbackRelease, String> {
+pub fn parse_fallback_release(body: &serde_json::Value) -> Result<CoreRelease, String> {
     let release = body
         .pointer("/platform_releases/windows")
         .or_else(|| body.get("release"))
@@ -186,7 +204,7 @@ pub fn parse_fallback_release(body: &serde_json::Value) -> Result<FallbackReleas
         .get("filename")
         .and_then(|v| v.as_str())
         .ok_or_else(|| "Missing filename in SourceForge JSON".to_string())?;
-    Ok(FallbackRelease {
+    Ok(CoreRelease {
         version: filename
             .split('/')
             .find(|s| !s.is_empty())
@@ -197,11 +215,13 @@ pub fn parse_fallback_release(body: &serde_json::Value) -> Result<FallbackReleas
             .and_then(|v| v.as_str())
             .ok_or_else(|| "Missing url in SourceForge JSON".to_string())?
             .to_owned(),
-        md5sum: release
-            .get("md5sum")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| "Missing md5sum in SourceForge JSON".to_string())?
-            .to_owned(),
+        checksum: Some(Checksum::Md5(
+            release
+                .get("md5sum")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| "Missing md5sum in SourceForge JSON".to_string())?
+                .to_owned(),
+        )),
     })
 }
 
@@ -249,6 +269,20 @@ mod tests {
             .release_download_url("1.2")
             .ends_with("/1.2/zapret-discord-youtube-1.2.zip"));
     }
+    #[test]
+    fn parses_sourceforge_release_with_md5() {
+        let body = serde_json::json!({
+            "platform_releases": { "windows": {
+                "filename": "/v1/archive.zip",
+                "url": "https://example.invalid/archive.zip",
+                "md5sum": "abcdef"
+            }}
+        });
+        let release = parse_fallback_release(&body).expect("fallback release");
+        assert_eq!(release.version, "v1");
+        assert_eq!(release.checksum, Some(Checksum::Md5("abcdef".to_string())));
+    }
+
     #[test]
     fn parses_local_version() {
         assert_eq!(

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -1,3 +1,3 @@
 mod flowseal;
 
-pub use flowseal::{parse_fallback_release, FlowsealProvider};
+pub use flowseal::FlowsealProvider;

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -1,0 +1,3 @@
+mod flowseal;
+
+pub use flowseal::{parse_fallback_release, FlowsealProvider};

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ZAPRET",
-  "version": "26.7.5",
+  "version": "26.7.6",
   "identifier": "com.alexx.zapret-ui",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/sections/settings.html
+++ b/src/components/sections/settings.html
@@ -31,6 +31,20 @@
         </label>
     </div>
 
+    <!-- Core rollback -->
+    <div id="core-rollback-panel" class="glass-panel rounded-2xl border border-outline-variant/10 p-6 space-y-3">
+        <div class="text-sm text-on-surface font-headline font-bold" data-i18n="core_rollback_title">Core rollback</div>
+        <div class="text-[10px] text-on-surface-variant">
+            <span data-i18n="core_current_version">Current version</span>: <span id="core-current-install-version">—</span>
+        </div>
+        <div id="core-previous-version-row" class="hidden text-[10px] text-on-surface-variant">
+            <span data-i18n="core_previous_version">Previous version</span>: <span id="core-previous-install-version">—</span>
+        </div>
+        <button id="core-rollback-btn" type="button" disabled
+            class="hidden px-4 py-2 bg-secondary/20 hover:bg-secondary/30 disabled:opacity-40 border border-secondary/20 rounded-xl text-xs font-bold text-secondary transition-all">
+        </button>
+    </div>
+
     <!-- Close button behavior -->
     <div class="glass-panel rounded-2xl border border-outline-variant/10 p-6 space-y-3">
         <div class="text-sm text-on-surface font-headline font-bold" data-i18n="close_pref_label">When the close button is clicked</div>

--- a/src/features/updates.js
+++ b/src/features/updates.js
@@ -30,9 +30,10 @@ async function downloadAndInstallCoreUpdate(useProxy = false, customProxy = null
   try {
     const modalTitle = document.querySelector('#update-modal h3');
     if (modalTitle) modalTitle.textContent = t('downloading_installing');
-    await invoke('download_and_install_update', { useProxy, customProxy });
-    if (modalTitle) modalTitle.textContent = t('update_installed_restarting');
-    setTimeout(() => location.reload(), 1500);
+    const result = await invoke('download_and_install_update', { useProxy, customProxy });
+    if (modalTitle) modalTitle.textContent = result;
+    setTimeout(() => location.reload(), 3000);
+    return result;
   } catch (err) {
     console.error('Core update failed:', err);
     showProxyFallbackModal(err, 
@@ -185,7 +186,10 @@ function showDualUpdateModal(data, manual = false) {
 
   modal.querySelector('#modal-close-btn')?.addEventListener('click', () => modal.remove());
   modal.querySelector('#modal-update-ui-btn')?.addEventListener('click', (e) => downloadAndInstallUIUpdate(e, currentUpdateObject));
-  modal.querySelector('#modal-update-core-btn')?.addEventListener('click', () => downloadAndInstallCoreUpdate().catch(console.error));
+  modal.querySelector('#modal-update-core-btn')?.addEventListener('click', (event) => {
+    event.currentTarget.disabled = true;
+    downloadAndInstallCoreUpdate().catch(console.error);
+  });
 }
 
 async function checkUIUpdateWithFallback() {
@@ -285,21 +289,7 @@ function initLegacyUpdateNowButton() {
     statusEl.className = 'mt-4 text-sm text-secondary';
     updateNowBtn.disabled = true;
 
-    let zapretWasRunning = false;
-    let zapretStrategy = null;
-    let zapretMode = 'service';
-
     try {
-      statusEl.textContent = t('checking_service_status');
-      const status = await invoke('get_zapret_status');
-      if (status.running) {
-        zapretWasRunning = true;
-        zapretStrategy = status.strategy;
-        zapretMode = status.mode || 'service';
-        statusEl.textContent = t('stopping_before_update');
-        await invoke('stop_zapret');
-      }
-
       const progressContainer = $('update-status-container');
       const progressText = $('update-progress-text');
       const progressBar = $('update-progress-bar');
@@ -321,19 +311,8 @@ function initLegacyUpdateNowButton() {
       if (progressText) progressText.textContent = '100%';
       statusEl.className = 'text-xs text-secondary font-mono mb-3 text-center';
 
-      if (zapretWasRunning && zapretStrategy) {
-        statusEl.textContent = t('update_installed_restarting');
-        try {
-          await invoke('start_zapret', { strategy: zapretStrategy, mode: zapretMode });
-          await pollStatus();
-          statusEl.textContent = result + ' Zapret restarted successfully.';
-        } catch (restartErr) {
-          statusEl.textContent = result + ' Warning: failed to restart: ' + restartErr;
-          statusEl.className = 'text-xs text-primary font-mono mb-3 text-center';
-        }
-      } else {
-        statusEl.textContent = result;
-      }
+      statusEl.textContent = result;
+      await pollStatus();
 
       await refreshCoreVersion();
 
@@ -343,9 +322,6 @@ function initLegacyUpdateNowButton() {
     } catch (err) {
       statusEl.textContent = 'Error: ' + err;
       statusEl.className = 'mt-4 text-sm text-error-dim';
-      if (zapretWasRunning && zapretStrategy) {
-        try { await invoke('start_zapret', { strategy: zapretStrategy, mode: zapretMode }); await pollStatus(); } catch {}
-      }
       updateNowBtn.disabled = false;
 
       showProxyFallbackModal(err, 
@@ -357,6 +333,45 @@ function initLegacyUpdateNowButton() {
   });
 }
 
+async function refreshRollbackState() {
+  const current = $('core-current-install-version');
+  const previous = $('core-previous-install-version');
+  const previousRow = $('core-previous-version-row');
+  const button = $('core-rollback-btn');
+  if (!current || !previous || !button) return;
+  try {
+    const installation = await invoke('get_core_installation_state');
+    current.textContent = installation.currentVersion || '—';
+    previous.textContent = installation.previousVersion || '—';
+    previousRow?.classList.toggle('hidden', !installation.previousVersion);
+    button.classList.toggle('hidden', !installation.rollbackAvailable);
+    button.disabled = !installation.rollbackAvailable;
+    button.textContent = t('core_rollback_button', { version: installation.previousVersion || '' });
+  } catch (err) {
+    console.error('Cannot read core installation state:', err);
+    button.disabled = true;
+  }
+}
+
+function initCoreRollback() {
+  const button = $('core-rollback-btn');
+  button?.addEventListener('click', async () => {
+    const version = $('core-previous-install-version')?.textContent || '';
+    if (!window.confirm(t('core_rollback_confirm', { version }))) return;
+    button.disabled = true;
+    try {
+      await invoke('rollback_core_update');
+      await refreshRollbackState();
+      await refreshCoreVersion();
+      alert(t('core_rollback_success'));
+    } catch (err) {
+      alert(`${t('core_rollback_title')}: ${err}`);
+      await refreshRollbackState();
+    }
+  });
+  refreshRollbackState();
+}
+
 export function initUpdates() {
   const checkUpdatesBtn = $('check-updates-btn');
   if (checkUpdatesBtn) checkUpdatesBtn.addEventListener('click', () => checkForUpdates(true));
@@ -364,4 +379,5 @@ export function initUpdates() {
 
   initIPSetUpdateButton();
   initLegacyUpdateNowButton();
+  initCoreRollback();
 }

--- a/src/features/updates.js
+++ b/src/features/updates.js
@@ -141,6 +141,11 @@ function showDualUpdateModal(data, manual = false) {
     unknown: t('core_update_unknown'),
   };
   const coreStatus = `<span class="${data.core.available ? 'text-secondary' : 'text-on-surface-variant/70'} text-[10px] font-bold uppercase">${coreStatusLabels[data.core.status] || t('core_update_unknown')}</span>`;
+  const coreCurrentVersion = data.core.status === 'not_installed'
+    ? t('core_not_installed')
+    : data.core.status === 'unknown'
+      ? t('core_version_unknown')
+      : `v${data.core.current}`;
 
   modal.innerHTML = `
     <div class="bg-surface-container-high border border-outline-variant/30 rounded-3xl p-8 max-w-lg w-full shadow-2xl animate-scale-in">
@@ -169,7 +174,7 @@ function showDualUpdateModal(data, manual = false) {
             <div class="flex flex-col items-start text-left">
               <span class="text-[10px] font-bold text-secondary/70 uppercase tracking-wider mb-1">${t('zapret_core')} · ${t('core_stable_channel')}</span>
               <div class="flex items-center gap-2">
-                <span class="text-sm font-bold text-on-surface">v${data.core.current}</span>
+                <span class="text-sm font-bold text-on-surface">${coreCurrentVersion}</span>
                 ${data.core.available ? `<span class="material-symbols-outlined text-xs text-on-surface-variant/40">arrow_forward</span> <span class="text-sm font-bold text-secondary">${data.core.latest === 'Error' ? 'Ошибка' : 'v' + data.core.latest}</span>` : ''}
               </div>
             </div>

--- a/src/features/updates.js
+++ b/src/features/updates.js
@@ -133,9 +133,14 @@ function showDualUpdateModal(data, manual = false) {
   const uiStatus = data.ui.available
     ? `<span class="px-2 py-0.5 bg-primary/20 text-primary text-[10px] font-bold rounded-full uppercase">${t('update_available_short')}</span>`
     : `<span class="text-on-surface-variant/50 text-[10px] font-bold uppercase">${t('up_to_date')}</span>`;
-  const coreStatus = data.core.available
-    ? `<span class="px-2 py-0.5 bg-secondary/20 text-secondary text-[10px] font-bold rounded-full uppercase">${t('update_available_short')}</span>`
-    : `<span class="text-on-surface-variant/50 text-[10px] font-bold uppercase">${t('up_to_date')}</span>`;
+  const coreStatusLabels = {
+    update_available: t('update_available_short'),
+    not_installed: t('core_not_installed'),
+    up_to_date: t('up_to_date'),
+    ahead: t('core_update_ahead'),
+    unknown: t('core_update_unknown'),
+  };
+  const coreStatus = `<span class="${data.core.available ? 'text-secondary' : 'text-on-surface-variant/70'} text-[10px] font-bold uppercase">${coreStatusLabels[data.core.status] || t('core_update_unknown')}</span>`;
 
   modal.innerHTML = `
     <div class="bg-surface-container-high border border-outline-variant/30 rounded-3xl p-8 max-w-lg w-full shadow-2xl animate-scale-in">
@@ -170,7 +175,7 @@ function showDualUpdateModal(data, manual = false) {
             </div>
             <div class="flex flex-col items-end gap-3">
               ${coreStatus}
-              ${data.core.available ? `<button id="modal-update-core-btn" class="px-4 py-2 bg-secondary/20 hover:bg-secondary/30 border border-secondary/20 rounded-xl text-[10px] font-black text-secondary uppercase transition-all active:scale-95 shadow-lg shadow-secondary/5">${t('update_now')}</button>` : ''}
+              ${(data.core.status === 'update_available' || data.core.status === 'not_installed') ? `<button id="modal-update-core-btn" class="px-4 py-2 bg-secondary/20 hover:bg-secondary/30 border border-secondary/20 rounded-xl text-[10px] font-black text-secondary uppercase transition-all active:scale-95 shadow-lg shadow-secondary/5">${t('update_now')}</button>` : ''}
             </div>
           </div>
         </div>
@@ -235,7 +240,7 @@ async function checkForUpdates(manual = false) {
     ]);
 
     const hasUIUpdate = !!uiUpdate;
-    const hasCoreUpdate = coreInfo.updateAvailable;
+    const hasCoreUpdate = coreInfo.status === 'update_available' || coreInfo.status === 'not_installed';
     const showCoreError = manual && coreInfo.status === 'unknown';
 
     if (hasUIUpdate || hasCoreUpdate || showCoreError || manual) {

--- a/src/features/updates.js
+++ b/src/features/updates.js
@@ -162,7 +162,7 @@ function showDualUpdateModal(data, manual = false) {
 
           <div class="flex items-center justify-between p-4 bg-white/5 rounded-2xl border border-white/5">
             <div class="flex flex-col items-start text-left">
-              <span class="text-[10px] font-bold text-secondary/70 uppercase tracking-wider mb-1">${t('zapret_core')}</span>
+              <span class="text-[10px] font-bold text-secondary/70 uppercase tracking-wider mb-1">${t('zapret_core')} · ${t('core_stable_channel')}</span>
               <div class="flex items-center gap-2">
                 <span class="text-sm font-bold text-on-surface">v${data.core.current}</span>
                 ${data.core.available ? `<span class="material-symbols-outlined text-xs text-on-surface-variant/40">arrow_forward</span> <span class="text-sm font-bold text-secondary">${data.core.latest === 'Error' ? 'Ошибка' : 'v' + data.core.latest}</span>` : ''}
@@ -223,26 +223,25 @@ async function checkForUpdates(manual = false) {
 
   try {
     const uiLocalVersion = await invoke('get_ui_version_cmd');
-    const [uiUpdate, coreRemoteVersion, coreLocalVersion] = await Promise.all([
+    const [uiUpdate, coreInfo] = await Promise.all([
       checkUIUpdateWithFallback(),
-      invoke('get_remote_core_version', { useProxy: false, customProxy: null }).catch(async (err) => {
+      invoke('get_core_update_info', { useProxy: false, customProxy: null }).catch(async (err) => {
         try {
-          return await invoke('get_remote_core_version', { useProxy: true, customProxy: null });
+          return await invoke('get_core_update_info', { useProxy: true, customProxy: null });
         } catch {
-          return 'Error';
+          return { status: 'unknown', currentVersion: 'Unknown', stableVersion: 'Error', updateAvailable: false };
         }
       }),
-      invoke('get_local_version_cmd').catch((err) => 'Local Err: ' + err),
     ]);
 
     const hasUIUpdate = !!uiUpdate;
-    const hasCoreUpdate = coreRemoteVersion !== 'Unknown' && coreRemoteVersion !== 'Error' && coreLocalVersion !== 'Unknown' && coreRemoteVersion !== coreLocalVersion;
-    const showCoreError = manual && coreRemoteVersion === 'Error';
+    const hasCoreUpdate = coreInfo.updateAvailable;
+    const showCoreError = manual && coreInfo.status === 'unknown';
 
     if (hasUIUpdate || hasCoreUpdate || showCoreError || manual) {
       showDualUpdateModal({
         ui: { available: hasUIUpdate, current: uiLocalVersion, latest: hasUIUpdate ? uiUpdate.version : uiLocalVersion, updateObj: uiUpdate },
-        core: { available: hasCoreUpdate || showCoreError, current: coreLocalVersion, latest: coreRemoteVersion },
+        core: { available: hasCoreUpdate, current: coreInfo.currentVersion || t('not_installed'), latest: coreInfo.stableVersion, status: coreInfo.status, error: showCoreError },
       }, manual);
     }
   } catch (err) {

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -3,6 +3,7 @@ export default {
     "core_update_unknown": "Core versions cannot be compared safely. Automatic update is unavailable.",
     "core_update_ahead": "Installed core is newer than Stable. No downgrade will be offered.",
     "core_not_installed": "Core is not installed",
+    "core_version_unknown": "Core version is unknown",
     "core_rollback_title": "Core rollback",
     "core_current_version": "Current version",
     "core_previous_version": "Previous version",

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -1,4 +1,6 @@
 export default {
+    "core_stable_channel": "Flowseal · Stable",
+    "core_update_unknown": "Core versions cannot be compared safely. Automatic update is unavailable.",
     "core_rollback_title": "Core rollback",
     "core_current_version": "Current version",
     "core_previous_version": "Previous version",

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -1,4 +1,10 @@
 export default {
+    "core_rollback_title": "Core rollback",
+    "core_current_version": "Current version",
+    "core_previous_version": "Previous version",
+    "core_rollback_button": "Return to version {version}",
+    "core_rollback_confirm": "The current core version will be replaced with {version}. User lists and settings will be preserved.",
+    "core_rollback_success": "Core rollback completed successfully.",
     "title": "Zapret_ VPN",
     "nav_home": "Home",
     "nav_sites": "Site Lists",

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -1,6 +1,8 @@
 export default {
     "core_stable_channel": "Flowseal · Stable",
     "core_update_unknown": "Core versions cannot be compared safely. Automatic update is unavailable.",
+    "core_update_ahead": "Installed core is newer than Stable. No downgrade will be offered.",
+    "core_not_installed": "Core is not installed",
     "core_rollback_title": "Core rollback",
     "core_current_version": "Current version",
     "core_previous_version": "Previous version",

--- a/src/i18n/ru.js
+++ b/src/i18n/ru.js
@@ -1,6 +1,8 @@
 export default {
     "core_stable_channel": "Flowseal · Stable",
     "core_update_unknown": "Версии ядра нельзя безопасно сравнить. Автоматическое обновление недоступно.",
+    "core_update_ahead": "Установленное ядро новее Stable. Понижение версии не предлагается.",
+    "core_not_installed": "Ядро не установлено",
     "core_rollback_title": "Откат ядра",
     "core_current_version": "Текущая версия",
     "core_previous_version": "Предыдущая версия",

--- a/src/i18n/ru.js
+++ b/src/i18n/ru.js
@@ -1,4 +1,10 @@
 export default {
+    "core_rollback_title": "Откат ядра",
+    "core_current_version": "Текущая версия",
+    "core_previous_version": "Предыдущая версия",
+    "core_rollback_button": "Вернуться к версии {version}",
+    "core_rollback_confirm": "Текущая версия ядра будет заменена на {version}. Пользовательские списки и настройки будут сохранены.",
+    "core_rollback_success": "Откат ядра успешно выполнен.",
     "title": "Zapret_ VPN",
     "nav_home": "Главная",
     "nav_sites": "Списки сайтов",

--- a/src/i18n/ru.js
+++ b/src/i18n/ru.js
@@ -1,4 +1,6 @@
 export default {
+    "core_stable_channel": "Flowseal · Stable",
+    "core_update_unknown": "Версии ядра нельзя безопасно сравнить. Автоматическое обновление недоступно.",
     "core_rollback_title": "Откат ядра",
     "core_current_version": "Текущая версия",
     "core_previous_version": "Предыдущая версия",

--- a/src/i18n/ru.js
+++ b/src/i18n/ru.js
@@ -3,6 +3,7 @@ export default {
     "core_update_unknown": "Версии ядра нельзя безопасно сравнить. Автоматическое обновление недоступно.",
     "core_update_ahead": "Установленное ядро новее Stable. Понижение версии не предлагается.",
     "core_not_installed": "Ядро не установлено",
+    "core_version_unknown": "Версия ядра неизвестна",
     "core_rollback_title": "Откат ядра",
     "core_current_version": "Текущая версия",
     "core_previous_version": "Предыдущая версия",


### PR DESCRIPTION
### Motivation
- Introduce a small, well-defined boundary between Tauri orchestration and the upstream Flowseal distribution so Flowseal-specific knowledge is isolated in one place. 
- Preserve all existing user-visible behavior and Tauri command contracts while enabling future work (multiple providers, manifests, staged installs) behind this boundary.

### Description
- Added `CoreProvider` trait and `CorePaths` abstraction and implemented a concrete `FlowsealProvider` that encapsulates Flowseal URLs, archive naming, SourceForge fallback parsing, local-version extraction, strategy discovery, natural sorting and BAT argument parsing (new files: `src-tauri/src/core/{mod.rs,paths.rs,provider.rs}`, `src-tauri/src/providers/{mod.rs,flowseal.rs}`).
- Updated `src-tauri/src/lib.rs` to delegate Flowseal-specific operations (version fetch, is-installed check, strategies listing, BAT parsing, IPSet/test-script paths, release URL construction) to the provider while keeping existing Tauri command names and signatures.
- Extracted SourceForge JSON parsing into `parse_fallback_release` and moved archive name / release API URL construction to the provider to avoid duplicating Flowseal constants across the codebase.
- Added platform-independent unit tests for core paths, archive naming, local-version parsing, strategy discovery/natural sort and multiline BAT parsing inside the new provider module.

### Testing
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml` passed and `node scripts/check-versions.mjs` passed. 
- `git diff --check` and staged diff checks passed and the local commit was created (`Extract Flowseal core provider`).
- `cargo test --manifest-path src-tauri/Cargo.toml` and `cargo clippy` could not complete in this Linux container because the system library `glib-2.0` (pkg-config) required by some crates is missing, so the Rust build failed on `glib-sys` (environment limitation rather than logic failure).
- `npm ci` / `npm run build` did not complete in this Linux environment because the lockfile includes a Windows-only native package (`@tailwindcss/oxide-win32-x64-msvc`), so frontend build steps must be validated on Windows or in an environment matching CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a650e3cf224833082c1c2cb3176b4d1)