### PR TITLE
Add robust core installation management with staging, activation, rollback and UI rollback controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,18 +25,17 @@ version.txt
 /logo.ico
 /logo.png
 
-# Local files & Binaries.
-# Everything under binaries/ is either downloaded from the Flowseal upstream at
-# first launch (*.bat, lists/, bin/, utils/) or is user-editable runtime state
-# (*.enabled, user lists). Keep a .gitkeep so the directory exists on clone —
-# `ensure_binaries_present` creates it otherwise, but tooling that expects the
-# folder on fresh checkouts is simpler this way.
+# Local files and downloaded core installations.
 *.local
 .env
 .env.*
 *.backup
-binaries/*
-!binaries/.gitkeep
+/binaries/
+/binaries.previous/
+/.binaries-staging-*/
+/.binaries-previous-backup/
+/.binaries-rollback-swap/
+/.binaries-rollback-restore-swap/
 
 # Editor & OS
 .vscode/*

--- a/src-tauri/src/core/installation.rs
+++ b/src-tauri/src/core/installation.rs
@@ -1,0 +1,882 @@
+use serde::{Deserialize, Serialize};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use super::{Checksum, CoreProvider};
+
+pub const MANIFEST_NAME: &str = ".zapret-ui-core.json";
+const SCHEMA_VERSION: u32 = 1;
+const STAGING_PREFIX: &str = ".binaries-staging-";
+const SWAP_NAME: &str = ".binaries-rollback-swap";
+const RESTORE_SWAP_NAME: &str = ".binaries-rollback-restore-swap";
+const PREVIOUS_BACKUP_NAME: &str = ".binaries-previous-backup";
+const USER_FILES: [&str; 3] = [
+    "list-general-user.txt",
+    "list-exclude-user.txt",
+    "ipset-exclude-user.txt",
+];
+const ACTIVE_FAKE_FILES: [&str; 2] = ["ACTIVE_DISCORD_UDP.bin", "ACTIVE_GAME_UDP.bin"];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CoreManifest {
+    pub schema_version: u32,
+    pub provider: String,
+    pub version: String,
+    pub source_url: Option<String>,
+    pub checksum: Option<Checksum>,
+    pub strategy_count: usize,
+    #[serde(default)]
+    pub imported_legacy: bool,
+}
+
+impl CoreManifest {
+    pub fn new(
+        provider: String,
+        version: String,
+        source_url: Option<String>,
+        checksum: Option<Checksum>,
+        strategy_count: usize,
+        imported_legacy: bool,
+    ) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            provider,
+            version,
+            source_url,
+            checksum,
+            strategy_count,
+            imported_legacy,
+        }
+    }
+
+    pub fn read(root: &Path) -> Result<Self, String> {
+        let path = root.join(MANIFEST_NAME);
+        let data = fs::read(&path).map_err(|e| {
+            format!(
+                "Core manifest is missing or unreadable ({}): {e}",
+                path.display()
+            )
+        })?;
+        let value: Self = serde_json::from_slice(&data)
+            .map_err(|e| format!("Core manifest is corrupted: {e}"))?;
+        if value.schema_version != SCHEMA_VERSION {
+            return Err(format!(
+                "Unsupported core manifest schema version: {}",
+                value.schema_version
+            ));
+        }
+        Ok(value)
+    }
+
+    pub fn write_atomic(&self, root: &Path) -> Result<(), String> {
+        let path = root.join(MANIFEST_NAME);
+        let temporary = root.join(format!("{MANIFEST_NAME}.tmp-{}", std::process::id()));
+        let data = serde_json::to_vec_pretty(self)
+            .map_err(|e| format!("Cannot serialize core manifest: {e}"))?;
+        fs::write(&temporary, data)
+            .map_err(|e| format!("Cannot write temporary core manifest: {e}"))?;
+        fs::rename(&temporary, &path).map_err(|e| format!("Cannot activate core manifest: {e}"))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CoreInstallationState {
+    pub current_version: Option<String>,
+    pub previous_version: Option<String>,
+    pub rollback_available: bool,
+}
+
+pub struct CoreInstallation {
+    parent: PathBuf,
+    active: PathBuf,
+    previous: PathBuf,
+}
+
+impl CoreInstallation {
+    pub fn new(active: impl Into<PathBuf>) -> Result<Self, String> {
+        let requested = active.into();
+        let parent = requested
+            .parent()
+            .ok_or_else(|| "Core directory has no parent".to_string())?
+            .canonicalize()
+            .map_err(|e| format!("Cannot verify core parent directory: {e}"))?;
+        if requested.file_name().and_then(|n| n.to_str()) != Some("binaries") {
+            return Err("Active core directory must be named binaries".into());
+        }
+        let active = parent.join("binaries");
+        Ok(Self {
+            previous: parent.join("binaries.previous"),
+            parent,
+            active,
+        })
+    }
+
+    pub fn recover(&self) -> Result<(), String> {
+        fs::create_dir_all(&self.parent).map_err(|e| format!("Cannot prepare core parent: {e}"))?;
+        self.recover_interrupted_rollback_restore()?;
+        self.recover_interrupted_rollback()?;
+        self.recover_interrupted_activation()?;
+        if !self.active.exists() && self.previous.exists() {
+            self.assert_owned(&self.previous, "binaries.previous")?;
+            fs::rename(&self.previous, &self.active)
+                .map_err(|e| format!("Cannot recover previous core: {e}"))?;
+            eprintln!("Recovered binaries.previous after an interrupted core update");
+        }
+        if self.active.exists() {
+            for entry in fs::read_dir(&self.parent).map_err(|e| e.to_string())? {
+                let path = entry.map_err(|e| e.to_string())?.path();
+                if path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with(STAGING_PREFIX))
+                {
+                    self.remove_owned_staging(&path)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn prepare(&self, provider: &dyn CoreProvider) -> Result<(), String> {
+        self.recover()?;
+        if self.active.is_dir() && !self.active.join(MANIFEST_NAME).exists() {
+            let (version, count) = provider.validate_installation()?;
+            CoreManifest::new(
+                provider.provider_name().into(),
+                version,
+                None,
+                None,
+                count,
+                true,
+            )
+            .write_atomic(&self.active)?;
+        }
+        Ok(())
+    }
+
+    pub fn state(&self) -> CoreInstallationState {
+        let current_version = CoreManifest::read(&self.active).ok().map(|m| m.version);
+        let previous_version = CoreManifest::read(&self.previous).ok().map(|m| m.version);
+        CoreInstallationState {
+            rollback_available: previous_version.is_some(),
+            current_version,
+            previous_version,
+        }
+    }
+
+    pub fn create_staging(&self) -> Result<PathBuf, String> {
+        fs::create_dir_all(&self.parent).map_err(|e| e.to_string())?;
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| e.to_string())?
+            .as_nanos();
+        let path = self
+            .parent
+            .join(format!("{STAGING_PREFIX}{}-{stamp}", std::process::id()));
+        fs::create_dir(&path).map_err(|e| format!("Cannot create staging directory: {e}"))?;
+        Ok(path)
+    }
+
+    pub fn validate_and_manifest(
+        &self,
+        root: &Path,
+        expected_version: &str,
+        source_url: Option<String>,
+        checksum: Option<Checksum>,
+        provider: &dyn CoreProvider,
+    ) -> Result<CoreManifest, String> {
+        self.assert_staging(root)?;
+        reject_symlinks(root)?;
+        let (actual, count) = provider.validate_installation()?;
+        if actual != expected_version {
+            return Err(format!(
+                "Core version mismatch: expected {expected_version}, found {actual}"
+            ));
+        }
+        let manifest = CoreManifest::new(
+            provider.provider_name().into(),
+            actual,
+            source_url,
+            checksum,
+            count,
+            false,
+        );
+        serde_json::to_vec(&manifest)
+            .map_err(|e| format!("Cannot serialize core manifest: {e}"))?;
+        manifest.write_atomic(root)?;
+        Ok(manifest)
+    }
+
+    pub fn preserve_user_files(&self, from: &Path, to: &Path) -> Result<(), String> {
+        let destination = to.join("lists");
+        fs::create_dir_all(&destination)
+            .map_err(|e| format!("Cannot create lists directory: {e}"))?;
+        for name in USER_FILES {
+            let source = from.join("lists").join(name);
+            if source.is_file() {
+                fs::copy(&source, destination.join(name))
+                    .map_err(|e| format!("Cannot preserve {name}: {e}"))?;
+            }
+        }
+        let destination_bin = to.join("bin");
+        for name in ACTIVE_FAKE_FILES {
+            let source = from.join("bin").join(name);
+            if source.is_file() {
+                fs::copy(&source, destination_bin.join(name))
+                    .map_err(|e| format!("Cannot preserve selected fake {name}: {e}"))?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn activate(
+        &self,
+        staging: &Path,
+        active_provider: &dyn CoreProvider,
+    ) -> Result<(), String> {
+        self.assert_staging(staging)?;
+        CoreManifest::read(staging)?;
+        if !self.active.is_dir() {
+            return Err("Active core is missing".into());
+        }
+        self.preserve_user_files(&self.active, staging)?;
+        let previous_backup = self.parent.join(PREVIOUS_BACKUP_NAME);
+        if previous_backup.exists() {
+            return Err("Previous-core backup already exists; recovery is required".into());
+        }
+        if self.previous.exists() {
+            self.assert_owned(&self.previous, "binaries.previous")?;
+            fs::rename(&self.previous, &previous_backup)
+                .map_err(|e| format!("Cannot preserve old previous core: {e}"))?;
+        }
+        if let Err(error) = fs::rename(&self.active, &self.previous) {
+            self.restore_previous_backup(&previous_backup)?;
+            return Err(format!("Cannot save active core: {error}"));
+        }
+        if let Err(error) = fs::rename(staging, &self.active) {
+            self.restore_failed_activation(&previous_backup)
+                .map_err(|rollback| {
+                    format!(
+                        "Activation failed ({error}); automatic rollback also failed: {rollback}"
+                    )
+                })?;
+            return Err(format!(
+                "Activation failed ({error}); automatic rollback completed"
+            ));
+        }
+        if let Err(error) = active_provider.validate_installation() {
+            let failed = self
+                .parent
+                .join(format!("{STAGING_PREFIX}failed-{}", std::process::id()));
+            fs::rename(&self.active, &failed).map_err(|e| {
+                format!(
+                    "Post-activation validation failed ({error}); cannot quarantine new core: {e}"
+                )
+            })?;
+            fs::rename(&self.previous, &self.active).map_err(|e| {
+                format!(
+                    "Post-activation validation failed ({error}); automatic rollback failed: {e}"
+                )
+            })?;
+            self.restore_previous_backup(&previous_backup)?;
+            self.remove_owned_staging(&failed)?;
+            return Err(format!(
+                "Post-activation validation failed ({error}); automatic rollback completed"
+            ));
+        }
+        if previous_backup.exists() {
+            self.assert_owned(&previous_backup, PREVIOUS_BACKUP_NAME)?;
+            fs::remove_dir_all(&previous_backup)
+                .map_err(|e| format!("Cannot remove committed previous-core backup: {e}"))?;
+        }
+        Ok(())
+    }
+
+    pub fn rollback(
+        &self,
+        active_provider: &dyn CoreProvider,
+        previous_provider: &dyn CoreProvider,
+    ) -> Result<CoreInstallationState, String> {
+        self.rollback_with_post_validation(previous_provider, || {
+            active_provider.validate_installation().map(|_| ())
+        })
+    }
+
+    fn rollback_with_post_validation(
+        &self,
+        previous_provider: &dyn CoreProvider,
+        post_validate: impl FnOnce() -> Result<(), String>,
+    ) -> Result<CoreInstallationState, String> {
+        if !self.previous.is_dir() {
+            return Err("Rollback is unavailable: previous core is missing".into());
+        }
+        CoreManifest::read(&self.previous)?;
+        previous_provider.validate_installation()?;
+        self.preserve_user_files(&self.active, &self.previous)?;
+        let swap = self.parent.join(SWAP_NAME);
+        if swap.exists() {
+            return Err("Rollback swap directory already exists; recovery is required".into());
+        }
+        fs::rename(&self.active, &swap).map_err(|e| format!("Cannot begin rollback: {e}"))?;
+        if let Err(error) = fs::rename(&self.previous, &self.active) {
+            fs::rename(&swap, &self.active)
+                .map_err(|e| format!("Rollback failed ({error}); restoration failed: {e}"))?;
+            return Err(format!("Rollback failed ({error}); active core restored"));
+        }
+        if let Err(error) = fs::rename(&swap, &self.previous) {
+            fs::rename(&self.active, &self.previous).map_err(|e| {
+                format!("Rollback swap failed ({error}); cannot move selected core back: {e}")
+            })?;
+            fs::rename(&swap, &self.active).map_err(|e| {
+                format!("Rollback swap failed ({error}); cannot restore active core: {e}")
+            })?;
+            return Err(format!(
+                "Rollback swap failed: {error}; active core restored"
+            ));
+        }
+        if let Err(validation_error) = post_validate() {
+            self.reverse_completed_rollback().map_err(|restore_error| {
+                format!(
+                    "Rollback post-validation failed ({validation_error}); restoration failed: {restore_error}"
+                )
+            })?;
+            return Err(format!(
+                "Rollback post-validation failed ({validation_error}); original installation restored"
+            ));
+        }
+        Ok(self.state())
+    }
+
+    fn reverse_completed_rollback(&self) -> Result<(), String> {
+        let swap = self.parent.join(RESTORE_SWAP_NAME);
+        if swap.exists() {
+            return Err("Rollback restore swap unexpectedly exists during restoration".into());
+        }
+        fs::rename(&self.active, &swap)
+            .map_err(|e| format!("Cannot move failed rollback core aside: {e}"))?;
+        if let Err(error) = fs::rename(&self.previous, &self.active) {
+            return Err(format!(
+                "Cannot restore original active core ({error}); recovery marker was retained"
+            ));
+        }
+        if let Err(error) = fs::rename(&swap, &self.previous) {
+            return Err(format!(
+                "Cannot restore original previous core ({error}); original active core is working and recovery marker was retained"
+            ));
+        }
+        Ok(())
+    }
+
+    fn recover_interrupted_rollback_restore(&self) -> Result<(), String> {
+        let restore_swap = self.parent.join(RESTORE_SWAP_NAME);
+        if !restore_swap.exists() {
+            return Ok(());
+        }
+        self.assert_owned(&restore_swap, RESTORE_SWAP_NAME)?;
+        match (self.active.exists(), self.previous.exists()) {
+            (false, true) => {
+                fs::rename(&self.previous, &self.active).map_err(|e| {
+                    format!("Cannot restore original active core during recovery: {e}")
+                })?;
+                fs::rename(&restore_swap, &self.previous).map_err(|e| {
+                    format!(
+                        "Original active core was recovered, but previous core restoration must be retried: {e}"
+                    )
+                })?;
+            }
+            (true, false) => {
+                fs::rename(&restore_swap, &self.previous).map_err(|e| {
+                    format!("Cannot finish previous core restoration during recovery: {e}")
+                })?;
+            }
+            (true, true) => {
+                return Err(
+                    "Ambiguous rollback restoration: active, previous, and restore swap all exist"
+                        .to_string(),
+                );
+            }
+            (false, false) => {
+                return Err(
+                    "Cannot recover rollback restoration: only the invalid restore swap remains"
+                        .to_string(),
+                );
+            }
+        }
+        eprintln!("Recovered interrupted rollback restoration");
+        Ok(())
+    }
+
+    fn recover_interrupted_rollback(&self) -> Result<(), String> {
+        let swap = self.parent.join(SWAP_NAME);
+        if !swap.exists() {
+            return Ok(());
+        }
+        self.assert_owned(&swap, SWAP_NAME)?;
+        match (self.active.exists(), self.previous.exists()) {
+            (false, true) => {
+                fs::rename(&swap, &self.active)
+                    .map_err(|e| format!("Cannot restore active core from rollback swap: {e}"))?;
+            }
+            (true, false) => {
+                fs::rename(&swap, &self.previous)
+                    .map_err(|e| format!("Cannot complete interrupted rollback from swap: {e}"))?;
+            }
+            (false, false) => {
+                fs::rename(&swap, &self.active)
+                    .map_err(|e| format!("Cannot recover sole core from rollback swap: {e}"))?;
+            }
+            (true, true) => {
+                return Err(
+                    "Ambiguous interrupted rollback: active, previous, and swap all exist"
+                        .to_string(),
+                );
+            }
+        }
+        eprintln!("Recovered interrupted core rollback");
+        Ok(())
+    }
+
+    fn recover_interrupted_activation(&self) -> Result<(), String> {
+        let backup = self.parent.join(PREVIOUS_BACKUP_NAME);
+        if !backup.exists() {
+            return Ok(());
+        }
+        self.assert_owned(&backup, PREVIOUS_BACKUP_NAME)?;
+        match (self.active.exists(), self.previous.exists()) {
+            (true, false) => self.restore_previous_backup(&backup)?,
+            (false, true) => self.restore_failed_activation(&backup)?,
+            (true, true) => {
+                fs::remove_dir_all(&backup)
+                    .map_err(|e| format!("Cannot clean committed previous-core backup: {e}"))?;
+            }
+            (false, false) => {
+                fs::rename(&backup, &self.active)
+                    .map_err(|e| format!("Cannot recover sole previous-core backup: {e}"))?;
+            }
+        }
+        eprintln!("Recovered interrupted core activation");
+        Ok(())
+    }
+
+    fn restore_failed_activation(&self, previous_backup: &Path) -> Result<(), String> {
+        fs::rename(&self.previous, &self.active)
+            .map_err(|e| format!("Cannot restore active core: {e}"))?;
+        self.restore_previous_backup(previous_backup)
+    }
+
+    fn restore_previous_backup(&self, previous_backup: &Path) -> Result<(), String> {
+        if previous_backup.exists() {
+            fs::rename(previous_backup, &self.previous)
+                .map_err(|e| format!("Cannot restore old previous core: {e}"))?;
+        }
+        Ok(())
+    }
+
+    pub fn remove_owned_staging(&self, path: &Path) -> Result<(), String> {
+        self.assert_staging(path)?;
+        if path.exists() {
+            reject_symlinks(path)?;
+            fs::remove_dir_all(path).map_err(|e| format!("Cannot remove staging: {e}"))?;
+        }
+        Ok(())
+    }
+
+    fn assert_staging(&self, path: &Path) -> Result<(), String> {
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+        if path.parent() != Some(self.parent.as_path()) || !name.starts_with(STAGING_PREFIX) {
+            return Err(format!("Refusing unsafe staging path: {}", path.display()));
+        }
+        Ok(())
+    }
+    fn assert_owned(&self, path: &Path, expected: &str) -> Result<(), String> {
+        if path.parent() != Some(self.parent.as_path())
+            || path.file_name().and_then(|n| n.to_str()) != Some(expected)
+        {
+            return Err(format!("Refusing unsafe core path: {}", path.display()));
+        }
+        reject_symlinks(path)
+    }
+}
+
+fn reject_symlinks(root: &Path) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(root)
+        .map_err(|e| format!("Cannot inspect {}: {e}", root.display()))?;
+    if metadata.file_type().is_symlink() {
+        return Err(format!(
+            "Symlink/junction is not allowed: {}",
+            root.display()
+        ));
+    }
+    if metadata.is_dir() {
+        for entry in fs::read_dir(root).map_err(|e| e.to_string())? {
+            reject_symlinks(&entry.map_err(|e| e.to_string())?.path())?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::CoreManager;
+
+    fn provider(root: &Path) -> &dyn CoreProvider {
+        // Managers are intentionally leaked only in tests so returned provider references
+        // remain valid for the duration of each isolated filesystem scenario.
+        Box::leak(Box::new(CoreManager::new(root))).provider()
+    }
+
+    struct Temp(PathBuf);
+    impl Temp {
+        fn new() -> Self {
+            let stamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "zapret-install-test-{}-{stamp}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).unwrap();
+            Self(path)
+        }
+    }
+    impl Drop for Temp {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn fixture(root: &Path, version: &str) {
+        fs::create_dir_all(root.join("bin")).unwrap();
+        fs::create_dir_all(root.join("lists")).unwrap();
+        fs::create_dir_all(root.join("utils")).unwrap();
+        fs::write(
+            root.join("service.bat"),
+            format!("set local_version={version}\n"),
+        )
+        .unwrap();
+        fs::write(root.join("general.bat"), "\"%BIN%winws.exe\" --wf-tcp=80\n").unwrap();
+        for file in ["winws.exe", "WinDivert.dll", "WinDivert64.sys"] {
+            fs::write(root.join("bin").join(file), b"fixture").unwrap();
+        }
+        fs::write(root.join("utils/test zapret.ps1"), b"fixture").unwrap();
+    }
+
+    fn manifest(version: &str) -> CoreManifest {
+        CoreManifest::new(
+            "fixture-provider".into(),
+            version.into(),
+            None,
+            None,
+            1,
+            false,
+        )
+    }
+
+    #[test]
+    fn manifest_round_trip_and_unknown_schema_rejected() {
+        let temp = Temp::new();
+        manifest("1.2.3").write_atomic(&temp.0).unwrap();
+        assert_eq!(CoreManifest::read(&temp.0).unwrap(), manifest("1.2.3"));
+        let mut invalid = manifest("1.2.3");
+        invalid.schema_version = 99;
+        fs::write(
+            temp.0.join(MANIFEST_NAME),
+            serde_json::to_vec(&invalid).unwrap(),
+        )
+        .unwrap();
+        assert!(CoreManifest::read(&temp.0)
+            .unwrap_err()
+            .contains("Unsupported"));
+    }
+
+    #[test]
+    fn imports_legacy_installation_without_moving_it() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        fixture(&active, "1.0.0");
+        let installation = CoreInstallation::new(&active).unwrap();
+        installation.prepare(provider(&active)).unwrap();
+        let imported = CoreManifest::read(&active).unwrap();
+        assert!(imported.imported_legacy);
+        assert_eq!(imported.version, "1.0.0");
+        assert!(!installation.state().rollback_available);
+    }
+
+    #[test]
+    fn validates_fixture_and_reports_missing_required_files() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        fs::create_dir(&active).unwrap();
+        let installation = CoreInstallation::new(&active).unwrap();
+        for missing in ["service.bat", "bin/winws.exe", "utils/test zapret.ps1"] {
+            let staging = installation.create_staging().unwrap();
+            fixture(&staging, "2.0.0");
+            fs::remove_file(staging.join(missing)).unwrap();
+            assert!(installation
+                .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+                .unwrap_err()
+                .contains("Missing required"));
+            installation.remove_owned_staging(&staging).unwrap();
+        }
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        installation
+            .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+            .unwrap();
+    }
+
+    #[test]
+    fn rejects_missing_bad_strategy_and_version_mismatch() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        fs::create_dir(&active).unwrap();
+        let installation = CoreInstallation::new(&active).unwrap();
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        fs::remove_file(staging.join("general.bat")).unwrap();
+        assert!(installation
+            .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+            .unwrap_err()
+            .contains("No Flowseal strategies"));
+        installation.remove_owned_staging(&staging).unwrap();
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        fs::write(staging.join("general.bat"), "invalid").unwrap();
+        assert!(installation
+            .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+            .unwrap_err()
+            .contains("cannot be parsed"));
+        installation.remove_owned_staging(&staging).unwrap();
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        assert!(installation
+            .validate_and_manifest(&staging, "3.0.0", None, None, provider(&staging))
+            .unwrap_err()
+            .contains("version mismatch"));
+    }
+
+    #[test]
+    fn activation_and_rollback_swap_versions_and_keep_current_lists() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        fixture(&active, "1.0.0");
+        manifest("1.0.0").write_atomic(&active).unwrap();
+        fs::write(active.join("lists/list-general-user.txt"), "current").unwrap();
+        let installation = CoreInstallation::new(&active).unwrap();
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        installation
+            .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+            .unwrap();
+        installation.activate(&staging, provider(&active)).unwrap();
+        assert_eq!(
+            installation.state().current_version.as_deref(),
+            Some("2.0.0")
+        );
+        fs::write(
+            active.join("lists/list-general-user.txt"),
+            "changed-after-update",
+        )
+        .unwrap();
+        let state = installation
+            .rollback(
+                provider(&active),
+                provider(&temp.0.join("binaries.previous")),
+            )
+            .unwrap();
+        assert_eq!(state.current_version.as_deref(), Some("1.0.0"));
+        assert_eq!(state.previous_version.as_deref(), Some("2.0.0"));
+        assert_eq!(
+            fs::read_to_string(active.join("lists/list-general-user.txt")).unwrap(),
+            "changed-after-update"
+        );
+    }
+
+    #[test]
+    fn rollback_unavailable_recovery_idempotent_and_removal_is_scoped() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let previous = temp.0.join("binaries.previous");
+        fixture(&previous, "1.0.0");
+        manifest("1.0.0").write_atomic(&previous).unwrap();
+        let installation = CoreInstallation::new(&active).unwrap();
+        installation.recover().unwrap();
+        installation.recover().unwrap();
+        assert!(active.is_dir());
+        assert!(installation
+            .rollback(
+                provider(&active),
+                provider(&temp.0.join("binaries.previous"))
+            )
+            .unwrap_err()
+            .contains("unavailable"));
+        let outside = temp.0.join("unrelated");
+        fs::create_dir(&outside).unwrap();
+        assert!(installation.remove_owned_staging(&outside).is_err());
+        assert!(outside.exists());
+    }
+
+    #[test]
+    fn recovers_every_interrupted_rollback_state_idempotently() {
+        for (active_exists, previous_exists) in [(false, true), (true, false), (false, false)] {
+            let temp = Temp::new();
+            let active = temp.0.join("binaries");
+            let previous = temp.0.join("binaries.previous");
+            let swap = temp.0.join(SWAP_NAME);
+            if active_exists {
+                fixture(&active, "2.0.0");
+                manifest("2.0.0").write_atomic(&active).unwrap();
+            }
+            if previous_exists {
+                fixture(&previous, "1.0.0");
+                manifest("1.0.0").write_atomic(&previous).unwrap();
+            }
+            fixture(&swap, "2.0.0");
+            manifest("2.0.0").write_atomic(&swap).unwrap();
+            let installation = CoreInstallation::new(&active).unwrap();
+            installation.recover().unwrap();
+            installation.recover().unwrap();
+            assert!(active.exists());
+            assert!(!swap.exists());
+            if active_exists && !previous_exists {
+                assert!(previous.exists());
+            }
+        }
+    }
+
+    #[test]
+    fn recovers_interrupted_activation_and_restores_old_previous() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let previous = temp.0.join("binaries.previous");
+        let backup = temp.0.join(PREVIOUS_BACKUP_NAME);
+        fixture(&previous, "2.0.0");
+        manifest("2.0.0").write_atomic(&previous).unwrap();
+        fixture(&backup, "0.9.0");
+        manifest("0.9.0").write_atomic(&backup).unwrap();
+        let installation = CoreInstallation::new(&active).unwrap();
+        installation.recover().unwrap();
+        installation.recover().unwrap();
+        assert_eq!(CoreManifest::read(&active).unwrap().version, "2.0.0");
+        assert_eq!(CoreManifest::read(&previous).unwrap().version, "0.9.0");
+        assert!(!backup.exists());
+    }
+
+    #[test]
+    fn successful_activation_replaces_previous_only_after_commit() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let previous = temp.0.join("binaries.previous");
+        fixture(&active, "1.0.0");
+        manifest("1.0.0").write_atomic(&active).unwrap();
+        fixture(&previous, "0.9.0");
+        manifest("0.9.0").write_atomic(&previous).unwrap();
+        let installation = CoreInstallation::new(&active).unwrap();
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        installation
+            .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+            .unwrap();
+        installation.activate(&staging, provider(&active)).unwrap();
+        assert_eq!(CoreManifest::read(&active).unwrap().version, "2.0.0");
+        assert_eq!(CoreManifest::read(&previous).unwrap().version, "1.0.0");
+        assert!(!temp.0.join(PREVIOUS_BACKUP_NAME).exists());
+    }
+
+    #[test]
+    fn failed_activation_restores_active_and_old_previous_and_cleans_candidate() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let previous = temp.0.join("binaries.previous");
+        fixture(&active, "1.0.0");
+        manifest("1.0.0").write_atomic(&active).unwrap();
+        fixture(&previous, "0.9.0");
+        manifest("0.9.0").write_atomic(&previous).unwrap();
+        let installation = CoreInstallation::new(&active).unwrap();
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        installation
+            .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+            .unwrap();
+        fs::remove_file(staging.join("service.bat")).unwrap();
+        assert!(installation
+            .activate(&staging, provider(&active))
+            .unwrap_err()
+            .contains("automatic rollback completed"));
+        assert_eq!(CoreManifest::read(&active).unwrap().version, "1.0.0");
+        assert_eq!(CoreManifest::read(&previous).unwrap().version, "0.9.0");
+        assert!(!staging.exists());
+        assert!(!temp.0.join(PREVIOUS_BACKUP_NAME).exists());
+    }
+
+    #[test]
+    fn rollback_post_validation_failure_restores_original_directories() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let previous = temp.0.join("binaries.previous");
+        fixture(&active, "2.0.0");
+        manifest("2.0.0").write_atomic(&active).unwrap();
+        fixture(&previous, "1.0.0");
+        manifest("1.0.0").write_atomic(&previous).unwrap();
+        let installation = CoreInstallation::new(&active).unwrap();
+        let error = installation
+            .rollback_with_post_validation(provider(&previous), || {
+                Err("simulated validation failure".to_string())
+            })
+            .unwrap_err();
+        assert!(error.contains("original installation restored"));
+        assert_eq!(CoreManifest::read(&active).unwrap().version, "2.0.0");
+        assert_eq!(CoreManifest::read(&previous).unwrap().version, "1.0.0");
+        assert!(!temp.0.join(SWAP_NAME).exists());
+    }
+
+    #[test]
+    fn recovers_rollback_restore_before_original_active_was_restored() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let previous = temp.0.join("binaries.previous");
+        let restore_swap = temp.0.join(RESTORE_SWAP_NAME);
+        fixture(&previous, "2.0.0");
+        manifest("2.0.0").write_atomic(&previous).unwrap();
+        fixture(&restore_swap, "1.0.0");
+        manifest("1.0.0").write_atomic(&restore_swap).unwrap();
+
+        let installation = CoreInstallation::new(&active).unwrap();
+        installation.recover().unwrap();
+        installation.recover().unwrap();
+
+        assert_eq!(CoreManifest::read(&active).unwrap().version, "2.0.0");
+        assert_eq!(CoreManifest::read(&previous).unwrap().version, "1.0.0");
+        assert!(!restore_swap.exists());
+    }
+
+    #[test]
+    fn recovers_rollback_restore_after_original_active_was_restored() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let previous = temp.0.join("binaries.previous");
+        let restore_swap = temp.0.join(RESTORE_SWAP_NAME);
+        fixture(&active, "2.0.0");
+        manifest("2.0.0").write_atomic(&active).unwrap();
+        fixture(&restore_swap, "1.0.0");
+        manifest("1.0.0").write_atomic(&restore_swap).unwrap();
+
+        let installation = CoreInstallation::new(&active).unwrap();
+        installation.recover().unwrap();
+        installation.recover().unwrap();
+
+        assert_eq!(CoreManifest::read(&active).unwrap().version, "2.0.0");
+        assert_eq!(CoreManifest::read(&previous).unwrap().version, "1.0.0");
+        assert!(!restore_swap.exists());
+    }
+}

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -1,7 +1,9 @@
+mod installation;
 mod manager;
 mod paths;
 mod provider;
 
+pub use installation::{CoreInstallation, CoreInstallationState};
 pub use manager::CoreManager;
 pub use paths::CorePaths;
 pub use provider::{Checksum, CoreProvider, CoreRelease};

--- a/src-tauri/src/core/provider.rs
+++ b/src-tauri/src/core/provider.rs
@@ -1,8 +1,10 @@
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 use super::CorePaths;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "algorithm", content = "value", rename_all = "lowercase")]
 pub enum Checksum {
     Sha256(String),
     Md5(String),
@@ -18,6 +20,7 @@ pub struct CoreRelease {
 
 /// Boundary between Tauri/core orchestration and an upstream core distribution.
 pub trait CoreProvider: Send + Sync {
+    fn provider_name(&self) -> &'static str;
     fn paths(&self) -> &CorePaths;
     fn version_url(&self) -> &'static str;
     fn release_api_url(&self, version: &str) -> String;
@@ -31,4 +34,6 @@ pub trait CoreProvider: Send + Sync {
     fn is_installed(&self) -> bool;
     fn strategies(&self) -> Result<Vec<String>, String>;
     fn parse_strategy(&self, strategy: &str, game_filter: &str) -> Result<String, String>;
+    /// Validates provider-specific on-disk structure and returns its version and strategy count.
+    fn validate_installation(&self) -> Result<(String, usize), String>;
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,10 +33,31 @@ use tauri_plugin_notification::NotificationExt;
 
 mod core;
 mod providers;
-use core::{Checksum, CoreManager, CoreRelease};
+use core::{Checksum, CoreInstallation, CoreInstallationState, CoreManager, CoreRelease};
 
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 const GITHUB_USER_AGENT: &str = "zapret-ui-updater";
+static CORE_OPERATION_ACTIVE: AtomicBool = AtomicBool::new(false);
+static EXIT_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+
+struct CoreOperationGuard;
+
+impl CoreOperationGuard {
+    fn acquire() -> Result<Self, String> {
+        CORE_OPERATION_ACTIVE
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .map_err(|_| {
+                "Another core update or rollback operation is already in progress".to_string()
+            })?;
+        Ok(Self)
+    }
+}
+
+impl Drop for CoreOperationGuard {
+    fn drop(&mut self) {
+        CORE_OPERATION_ACTIVE.store(false, Ordering::Release);
+    }
+}
 
 struct AppState {
     active_strategy: Mutex<Option<String>>,
@@ -74,6 +95,23 @@ struct ZapretStatus {
     running: bool,
     strategy: Option<String>,
     mode: Option<String>,
+}
+
+fn restart_context(
+    status: ZapretStatus,
+    operation: &str,
+) -> Result<Option<(String, String)>, String> {
+    if !status.running {
+        return Ok(None);
+    }
+    Ok(Some((
+        status.strategy.ok_or_else(|| {
+            format!("Cannot {operation} while zapret is running: active strategy is unknown")
+        })?,
+        status.mode.ok_or_else(|| {
+            format!("Cannot {operation} while zapret is running: launch mode is unknown")
+        })?,
+    )))
 }
 
 #[derive(serde::Serialize)]
@@ -1743,37 +1781,34 @@ fn is_ip_or_cidr(s: &str) -> bool {
 
 #[tauri::command]
 async fn download_and_install_update(
+    app: tauri::AppHandle,
     window: tauri::Window,
     use_proxy: Option<bool>,
     custom_proxy: Option<String>,
+    state: State<'_, AppState>,
 ) -> Result<String, String> {
-    // Stop the zapret service and processes to release file locks before update
-    let _ = stop_zapret_internal();
-
-    let filters_status = get_filters_status();
+    let _operation_guard = CoreOperationGuard::acquire()?;
     let dir = find_binaries_dir();
-    let temp_dir = std::env::temp_dir().join("zapret_update");
+    let installation = CoreInstallation::new(&dir)?;
+    let manager = core_manager_at(&dir);
+    installation.prepare(manager.provider())?;
+    let temp_parent = std::env::temp_dir();
+    let temp_dir = temp_parent.join(format!(
+        ".zapret-ui-core-download-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| format!("System clock error: {e}"))?
+            .as_nanos()
+    ));
 
     // Create temp directory
-    let _ = std::fs::remove_dir_all(&temp_dir);
     std::fs::create_dir_all(&temp_dir).map_err(|e| format!("Failed to create temp dir: {}", e))?;
-
-    // Backup user files
-    let lists_dir = dir.join("lists");
-    let backup_dir = temp_dir.join("backup");
-    std::fs::create_dir_all(&backup_dir).ok();
-
-    if lists_dir.exists() {
-        if let Ok(entries) = std::fs::read_dir(&lists_dir) {
-            for entry in entries.flatten() {
-                if let Some(name) = entry.file_name().to_str() {
-                    if name.contains("user") {
-                        let _ = std::fs::copy(entry.path(), backup_dir.join(name));
-                    }
-                }
-            }
-        }
-    }
+    let _download_cleanup = OwnedDirectoryCleanup::new(
+        temp_dir.clone(),
+        temp_parent.canonicalize().map_err(|e| e.to_string())?,
+        ".zapret-ui-core-download-",
+    );
 
     window.emit("download-progress", 5).ok();
 
@@ -1794,7 +1829,6 @@ async fn download_and_install_update(
         .map_err(|e| format!("Failed to build http client: {}", e))?;
 
     // Fetch version from GitHub with fallback to SourceForge
-    let manager = core_manager_at(&dir);
     let provider = manager.provider();
     let mut fetched_from_sf = false;
     let mut sf_info: Option<CoreRelease> = None;
@@ -1947,7 +1981,9 @@ async fn download_and_install_update(
         return Err("Download failed: output file not found".to_string());
     }
 
-    // Verify integrity of downloaded archive
+    // Verify integrity of downloaded archive before extraction.
+    let verified_checksum;
+    let source_url;
     if downloaded_from_sf {
         if let Some(info) = sf_info {
             let expected_md5 = match info.checksum {
@@ -1966,6 +2002,8 @@ async fn download_and_install_update(
                     expected_md5, actual_md5
                 ));
             }
+            verified_checksum = Checksum::Md5(expected_md5);
+            source_url = Some(info.download_url);
         } else {
             return Err("Downloaded from SourceForge but release metadata is missing".to_string());
         }
@@ -1985,18 +2023,32 @@ async fn download_and_install_update(
                 asset_name, expected_sha256, actual_sha256
             ));
         }
+        verified_checksum = Checksum::Sha256(expected_sha256);
+        source_url = Some(provider.release_download_url(&latest_version));
     }
 
     // Extraction
     window.emit("download-progress", 92).ok();
-    let extract_dir = temp_dir.join("extracted");
-    let _ = std::fs::create_dir_all(&extract_dir);
+    let staging = installation.create_staging()?;
+    let _staging_cleanup = OwnedDirectoryCleanup::new(
+        staging.clone(),
+        staging
+            .parent()
+            .ok_or_else(|| "Staging has no parent".to_string())?
+            .to_path_buf(),
+        ".binaries-staging-",
+    );
+    let extract_dir = staging.join("package");
+    std::fs::create_dir(&extract_dir).map_err(|e| format!("Failed to prepare staging: {e}"))?;
 
     // Extract natively via the `zip` crate instead of calling
     // `Expand-Archive`. Every entry name is validated against `..`, absolute
     // paths, and drive-letter prefixes before it is written, preventing
     // zip-slip from placing files outside `extract_dir`.
-    extract_zip_safely(&zip_path, &extract_dir)?;
+    if let Err(error) = extract_zip_safely(&zip_path, &extract_dir) {
+        installation.remove_owned_staging(&staging)?;
+        return Err(error);
+    }
 
     window.emit("download-progress", 95).ok();
 
@@ -2008,25 +2060,258 @@ async fn download_and_install_update(
         }
     }
 
-    copy_dir_contents(&extracted_folder, &dir)?;
+    if let Err(error) = copy_dir_contents(&extracted_folder, &staging) {
+        installation.remove_owned_staging(&staging)?;
+        return Err(error);
+    }
+    std::fs::remove_dir_all(&extract_dir)
+        .map_err(|e| format!("Cannot remove staging package directory: {e}"))?;
+    if let Err(error) = installation.validate_and_manifest(
+        &staging,
+        &latest_version,
+        source_url,
+        Some(verified_checksum),
+        core_manager_at(&staging).provider(),
+    ) {
+        installation.remove_owned_staging(&staging)?;
+        return Err(error);
+    }
+    installation.preserve_user_files(&dir, &staging)?;
 
-    // Restore
-    let new_lists_dir = dir.join("lists");
-    let _ = std::fs::create_dir_all(&new_lists_dir);
-    if let Ok(entries) = std::fs::read_dir(&backup_dir) {
-        for entry in entries.flatten() {
-            let _ = std::fs::copy(entry.path(), new_lists_dir.join(entry.file_name()));
+    // Capture the exact runtime state only after the candidate is ready, just
+    // before stopping anything managed by the application.
+    let restart = restart_context(get_zapret_status(state.clone()), "update")?;
+    let filters_status = get_filters_status();
+    if restart.is_some() {
+        if let Err(error) = stop_zapret_internal() {
+            installation.remove_owned_staging(&staging)?;
+            return Err(format!("Cannot stop zapret before activation: {error}"));
         }
     }
 
-    // Restore settings after update
-    let _ = set_game_filter(filters_status.game_filter);
-    let _ = set_ipset_filter(filters_status.ipset);
+    let operation = (|| {
+        installation.activate(&staging, manager.provider())?;
+        if let Err(error) = set_game_filter(filters_status.game_filter)
+            .and_then(|_| set_ipset_filter(filters_status.ipset))
+        {
+            installation
+                .rollback(
+                    manager.provider(),
+                    core_manager_at(dir.with_file_name("binaries.previous")).provider(),
+                )
+                .map_err(|rollback| {
+                    format!(
+                        "Cannot restore filter settings ({error}); automatic rollback failed: {rollback}"
+                    )
+                })?;
+            return Err(format!(
+                "Cannot restore filter settings ({error}); automatic rollback completed"
+            ));
+        }
+        Ok(())
+    })();
 
-    let _ = std::fs::remove_dir_all(&temp_dir);
-    window.emit("download-progress", 100).ok();
+    let restart_result = restart.map(|(strategy, mode)| {
+        start_zapret(app, strategy, mode, state)
+            .map(|_| ())
+            .map_err(|e| format!("Cannot restart zapret after core update: {e}"))
+    });
+    match (operation, restart_result) {
+        (Err(error), Some(Err(restart_error))) => Err(format!("{error}; {restart_error}")),
+        (Err(error), _) => Err(error),
+        (Ok(()), Some(Err(restart_error))) => {
+            window.emit("download-progress", 100).ok();
+            Ok(format!("Update successful. Warning: {restart_error}"))
+        }
+        (Ok(()), _) => {
+            window.emit("download-progress", 100).ok();
+            Ok("Update successful".to_string())
+        }
+    }
+}
 
-    Ok("Update successful".to_string())
+struct OwnedDirectoryCleanup {
+    path: PathBuf,
+    expected_parent: PathBuf,
+    prefix: &'static str,
+}
+
+impl OwnedDirectoryCleanup {
+    fn new(path: PathBuf, expected_parent: PathBuf, prefix: &'static str) -> Self {
+        Self {
+            path,
+            expected_parent,
+            prefix,
+        }
+    }
+}
+
+impl Drop for OwnedDirectoryCleanup {
+    fn drop(&mut self) {
+        if !self.path.exists() {
+            return;
+        }
+        let actual_parent = self
+            .path
+            .parent()
+            .and_then(|parent| parent.canonicalize().ok());
+        let expected_parent = self.expected_parent.canonicalize().ok();
+        let owned = actual_parent == expected_parent
+            && self
+                .path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(self.prefix));
+        let safe_type = std::fs::symlink_metadata(&self.path)
+            .map(|metadata| !metadata.file_type().is_symlink())
+            .unwrap_or(false);
+        if owned && safe_type {
+            if let Err(error) = std::fs::remove_dir_all(&self.path) {
+                eprintln!(
+                    "Cannot clean owned temporary directory {}: {error}",
+                    self.path.display()
+                );
+            }
+        } else {
+            eprintln!(
+                "Refusing to clean unverified temporary directory {}",
+                self.path.display()
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod temporary_cleanup_tests {
+    use super::{restart_context, CoreOperationGuard, OwnedDirectoryCleanup, ZapretStatus};
+
+    #[test]
+    fn restart_context_preserves_service_and_temporary_modes() {
+        for mode in ["service", "temporary"] {
+            let context = restart_context(
+                ZapretStatus {
+                    running: true,
+                    strategy: Some("ALT12".to_string()),
+                    mode: Some(mode.to_string()),
+                },
+                "update",
+            )
+            .unwrap();
+            assert_eq!(context, Some(("ALT12".to_string(), mode.to_string())));
+        }
+        assert_eq!(
+            restart_context(
+                ZapretStatus {
+                    running: false,
+                    strategy: None,
+                    mode: None,
+                },
+                "update",
+            )
+            .unwrap(),
+            None
+        );
+        assert!(restart_context(
+            ZapretStatus {
+                running: true,
+                strategy: None,
+                mode: Some("service".to_string()),
+            },
+            "update",
+        )
+        .unwrap_err()
+        .contains("active strategy is unknown"));
+    }
+
+    #[test]
+    fn core_operation_guard_rejects_overlap_and_resets_on_drop() {
+        let guard = CoreOperationGuard::acquire().unwrap();
+        assert!(CoreOperationGuard::acquire()
+            .err()
+            .unwrap()
+            .contains("already in progress"));
+        drop(guard);
+        assert!(CoreOperationGuard::acquire().is_ok());
+    }
+
+    #[test]
+    fn owned_temporary_directory_is_cleaned_during_error_unwind() {
+        let temp_parent = std::env::temp_dir();
+        let expected_parent = temp_parent.canonicalize().unwrap();
+        for prefix in [".zapret-ui-core-download-", ".binaries-staging-"] {
+            let path = temp_parent.join(format!("{prefix}test-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir(&path).unwrap();
+            let result: Result<(), &str> = (|| {
+                let _cleanup =
+                    OwnedDirectoryCleanup::new(path.clone(), expected_parent.clone(), prefix);
+                Err("simulated failure")
+            })();
+            assert!(result.is_err());
+            assert!(!path.exists());
+        }
+    }
+}
+
+#[tauri::command]
+fn get_core_installation_state() -> Result<CoreInstallationState, String> {
+    let dir = find_binaries_dir();
+    let installation = CoreInstallation::new(&dir)?;
+    installation.prepare(core_manager_at(dir).provider())?;
+    Ok(installation.state())
+}
+
+#[tauri::command]
+fn rollback_core_update(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Result<CoreInstallationState, String> {
+    let _operation_guard = CoreOperationGuard::acquire()?;
+    let dir = find_binaries_dir();
+    let previous_dir = dir.with_file_name("binaries.previous");
+    let installation = CoreInstallation::new(&dir)?;
+    let active_manager = core_manager_at(&dir);
+    installation.prepare(active_manager.provider())?;
+    let filters = get_filters_status();
+    let restart = restart_context(get_zapret_status(state.clone()), "rollback")?;
+    if restart.is_some() {
+        stop_zapret_internal().map_err(|e| format!("Cannot stop zapret before rollback: {e}"))?;
+    }
+
+    let operation = (|| {
+        let result = installation.rollback(
+            active_manager.provider(),
+            core_manager_at(&previous_dir).provider(),
+        )?;
+        if let Err(error) =
+            set_game_filter(filters.game_filter).and_then(|_| set_ipset_filter(filters.ipset))
+        {
+            installation
+                .rollback(
+                    active_manager.provider(),
+                    core_manager_at(&previous_dir).provider(),
+                )
+                .map_err(|restore| {
+                    format!(
+                        "Cannot restore settings after rollback ({error}); cannot undo rollback: {restore}"
+                    )
+                })?;
+            return Err(format!(
+                "Cannot restore settings after rollback ({error}); original core restored"
+            ));
+        }
+        Ok(result)
+    })();
+
+    let restart_result = restart.map(|(strategy, mode)| {
+        start_zapret(app, strategy, mode, state)
+            .map_err(|e| format!("Cannot restart zapret after rollback attempt: {e}"))
+    });
+    match (operation, restart_result) {
+        (Ok(_), Some(Err(error))) => Err(error),
+        (Err(error), Some(Err(restart))) => Err(format!("{error}; {restart}")),
+        (result, _) => result,
+    }
 }
 
 /// Recursively copies directory contents
@@ -3177,8 +3462,21 @@ fn refresh_tray_menu(app: &tauri::AppHandle) {
 }
 
 #[tauri::command]
-fn exit_app(app: tauri::AppHandle, state: State<'_, AppState>) {
-    stop_zapret_on_exit(state);
+fn exit_app(app: tauri::AppHandle) {
+    graceful_exit(&app);
+}
+
+fn graceful_exit(app: &tauri::AppHandle) {
+    if EXIT_IN_PROGRESS.swap(true, Ordering::AcqRel) {
+        return;
+    }
+
+    stop_zapret_on_exit(app.state::<AppState>());
+    if let Some(window) = app.get_webview_window("main") {
+        if let Err(error) = window.destroy() {
+            eprintln!("Failed to destroy main WebView window during shutdown: {error}");
+        }
+    }
     app.exit(0);
 }
 
@@ -3285,9 +3583,7 @@ pub fn run() {
                 .on_menu_event(move |app, event| {
                     match event.id.as_ref() {
                         "quit" => {
-                            let state = app.state::<AppState>();
-                            stop_zapret_on_exit(state);
-                            app.exit(0);
+                            graceful_exit(app);
                         }
                         "show" => {
                             if let Some(window) = app.get_webview_window("main") {
@@ -3448,6 +3744,8 @@ pub fn run() {
             update_ipset_list,
             get_remote_core_version,
             download_and_install_update,
+            get_core_installation_state,
+            rollback_core_update,
             run_diagnostics,
             clear_discord_cache,
             check_admin_privileges,

--- a/src-tauri/src/providers/flowseal.rs
+++ b/src-tauri/src/providers/flowseal.rs
@@ -124,6 +124,9 @@ impl FlowsealProvider {
 }
 
 impl CoreProvider for FlowsealProvider {
+    fn provider_name(&self) -> &'static str {
+        "flowseal"
+    }
     fn paths(&self) -> &CorePaths {
         &self.paths
     }
@@ -192,6 +195,49 @@ impl CoreProvider for FlowsealProvider {
         let content = std::fs::read_to_string(self.paths.root().join(format!("{strategy}.bat")))
             .map_err(|e| format!("Не удалось прочитать {strategy}.bat: {e}"))?;
         self.parse_strategy_content(&content, strategy, game_filter)
+    }
+    fn validate_installation(&self) -> Result<(String, usize), String> {
+        let root = self.paths.root();
+        if !root.is_dir() {
+            return Err(format!(
+                "Unexpected archive structure: {} is not a directory",
+                root.display()
+            ));
+        }
+        for path in [
+            self.service_script(),
+            self.winws_executable(),
+            self.test_script(),
+        ] {
+            if !path.is_file() {
+                return Err(format!("Missing required file: {}", path.display()));
+            }
+        }
+        for path in [self.paths.lists_dir(), self.paths.utils_dir()] {
+            if !path.is_dir() {
+                return Err(format!("Missing required directory: {}", path.display()));
+            }
+        }
+        let windivert = self.paths.bin_dir().join("WinDivert.dll");
+        let windivert64 = self.paths.bin_dir().join("WinDivert64.sys");
+        for path in [windivert, windivert64] {
+            if !path.is_file() {
+                return Err(format!("Missing required file: {}", path.display()));
+            }
+        }
+        let strategies = self.strategies()?;
+        if strategies.is_empty() {
+            return Err("No Flowseal strategies found".to_string());
+        }
+        for strategy in &strategies {
+            self.parse_strategy(strategy, "all")
+                .map_err(|e| format!("Strategy {strategy} cannot be parsed: {e}"))?;
+        }
+        let version = self.local_version();
+        if version.starts_with("Err:") {
+            return Err(format!("Cannot determine Flowseal version: {version}"));
+        }
+        Ok((version, strategies.len()))
     }
 }
 

--- a/src/components/sections/settings.html
+++ b/src/components/sections/settings.html
@@ -31,6 +31,20 @@
         </label>
     </div>
 
+    <!-- Core rollback -->
+    <div id="core-rollback-panel" class="glass-panel rounded-2xl border border-outline-variant/10 p-6 space-y-3">
+        <div class="text-sm text-on-surface font-headline font-bold" data-i18n="core_rollback_title">Core rollback</div>
+        <div class="text-[10px] text-on-surface-variant">
+            <span data-i18n="core_current_version">Current version</span>: <span id="core-current-install-version">—</span>
+        </div>
+        <div id="core-previous-version-row" class="hidden text-[10px] text-on-surface-variant">
+            <span data-i18n="core_previous_version">Previous version</span>: <span id="core-previous-install-version">—</span>
+        </div>
+        <button id="core-rollback-btn" type="button" disabled
+            class="hidden px-4 py-2 bg-secondary/20 hover:bg-secondary/30 disabled:opacity-40 border border-secondary/20 rounded-xl text-xs font-bold text-secondary transition-all">
+        </button>
+    </div>
+
     <!-- Close button behavior -->
     <div class="glass-panel rounded-2xl border border-outline-variant/10 p-6 space-y-3">
         <div class="text-sm text-on-surface font-headline font-bold" data-i18n="close_pref_label">When the close button is clicked</div>

--- a/src/features/updates.js
+++ b/src/features/updates.js
@@ -30,9 +30,10 @@ async function downloadAndInstallCoreUpdate(useProxy = false, customProxy = null
   try {
     const modalTitle = document.querySelector('#update-modal h3');
     if (modalTitle) modalTitle.textContent = t('downloading_installing');
-    await invoke('download_and_install_update', { useProxy, customProxy });
-    if (modalTitle) modalTitle.textContent = t('update_installed_restarting');
-    setTimeout(() => location.reload(), 1500);
+    const result = await invoke('download_and_install_update', { useProxy, customProxy });
+    if (modalTitle) modalTitle.textContent = result;
+    setTimeout(() => location.reload(), 3000);
+    return result;
   } catch (err) {
     console.error('Core update failed:', err);
     showProxyFallbackModal(err, 
@@ -185,7 +186,10 @@ function showDualUpdateModal(data, manual = false) {
 
   modal.querySelector('#modal-close-btn')?.addEventListener('click', () => modal.remove());
   modal.querySelector('#modal-update-ui-btn')?.addEventListener('click', (e) => downloadAndInstallUIUpdate(e, currentUpdateObject));
-  modal.querySelector('#modal-update-core-btn')?.addEventListener('click', () => downloadAndInstallCoreUpdate().catch(console.error));
+  modal.querySelector('#modal-update-core-btn')?.addEventListener('click', (event) => {
+    event.currentTarget.disabled = true;
+    downloadAndInstallCoreUpdate().catch(console.error);
+  });
 }
 
 async function checkUIUpdateWithFallback() {
@@ -285,21 +289,7 @@ function initLegacyUpdateNowButton() {
     statusEl.className = 'mt-4 text-sm text-secondary';
     updateNowBtn.disabled = true;
 
-    let zapretWasRunning = false;
-    let zapretStrategy = null;
-    let zapretMode = 'service';
-
     try {
-      statusEl.textContent = t('checking_service_status');
-      const status = await invoke('get_zapret_status');
-      if (status.running) {
-        zapretWasRunning = true;
-        zapretStrategy = status.strategy;
-        zapretMode = status.mode || 'service';
-        statusEl.textContent = t('stopping_before_update');
-        await invoke('stop_zapret');
-      }
-
       const progressContainer = $('update-status-container');
       const progressText = $('update-progress-text');
       const progressBar = $('update-progress-bar');
@@ -321,19 +311,8 @@ function initLegacyUpdateNowButton() {
       if (progressText) progressText.textContent = '100%';
       statusEl.className = 'text-xs text-secondary font-mono mb-3 text-center';
 
-      if (zapretWasRunning && zapretStrategy) {
-        statusEl.textContent = t('update_installed_restarting');
-        try {
-          await invoke('start_zapret', { strategy: zapretStrategy, mode: zapretMode });
-          await pollStatus();
-          statusEl.textContent = result + ' Zapret restarted successfully.';
-        } catch (restartErr) {
-          statusEl.textContent = result + ' Warning: failed to restart: ' + restartErr;
-          statusEl.className = 'text-xs text-primary font-mono mb-3 text-center';
-        }
-      } else {
-        statusEl.textContent = result;
-      }
+      statusEl.textContent = result;
+      await pollStatus();
 
       await refreshCoreVersion();
 
@@ -343,9 +322,6 @@ function initLegacyUpdateNowButton() {
     } catch (err) {
       statusEl.textContent = 'Error: ' + err;
       statusEl.className = 'mt-4 text-sm text-error-dim';
-      if (zapretWasRunning && zapretStrategy) {
-        try { await invoke('start_zapret', { strategy: zapretStrategy, mode: zapretMode }); await pollStatus(); } catch {}
-      }
       updateNowBtn.disabled = false;
 
       showProxyFallbackModal(err, 
@@ -357,6 +333,45 @@ function initLegacyUpdateNowButton() {
   });
 }
 
+async function refreshRollbackState() {
+  const current = $('core-current-install-version');
+  const previous = $('core-previous-install-version');
+  const previousRow = $('core-previous-version-row');
+  const button = $('core-rollback-btn');
+  if (!current || !previous || !button) return;
+  try {
+    const installation = await invoke('get_core_installation_state');
+    current.textContent = installation.currentVersion || '—';
+    previous.textContent = installation.previousVersion || '—';
+    previousRow?.classList.toggle('hidden', !installation.previousVersion);
+    button.classList.toggle('hidden', !installation.rollbackAvailable);
+    button.disabled = !installation.rollbackAvailable;
+    button.textContent = t('core_rollback_button', { version: installation.previousVersion || '' });
+  } catch (err) {
+    console.error('Cannot read core installation state:', err);
+    button.disabled = true;
+  }
+}
+
+function initCoreRollback() {
+  const button = $('core-rollback-btn');
+  button?.addEventListener('click', async () => {
+    const version = $('core-previous-install-version')?.textContent || '';
+    if (!window.confirm(t('core_rollback_confirm', { version }))) return;
+    button.disabled = true;
+    try {
+      await invoke('rollback_core_update');
+      await refreshRollbackState();
+      await refreshCoreVersion();
+      alert(t('core_rollback_success'));
+    } catch (err) {
+      alert(`${t('core_rollback_title')}: ${err}`);
+      await refreshRollbackState();
+    }
+  });
+  refreshRollbackState();
+}
+
 export function initUpdates() {
   const checkUpdatesBtn = $('check-updates-btn');
   if (checkUpdatesBtn) checkUpdatesBtn.addEventListener('click', () => checkForUpdates(true));
@@ -364,4 +379,5 @@ export function initUpdates() {
 
   initIPSetUpdateButton();
   initLegacyUpdateNowButton();
+  initCoreRollback();
 }

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -1,4 +1,10 @@
 export default {
+    "core_rollback_title": "Core rollback",
+    "core_current_version": "Current version",
+    "core_previous_version": "Previous version",
+    "core_rollback_button": "Return to version {version}",
+    "core_rollback_confirm": "The current core version will be replaced with {version}. User lists and settings will be preserved.",
+    "core_rollback_success": "Core rollback completed successfully.",
     "title": "Zapret_ VPN",
     "nav_home": "Home",
     "nav_sites": "Site Lists",

--- a/src/i18n/ru.js
+++ b/src/i18n/ru.js
@@ -1,4 +1,10 @@
 export default {
+    "core_rollback_title": "Откат ядра",
+    "core_current_version": "Текущая версия",
+    "core_previous_version": "Предыдущая версия",
+    "core_rollback_button": "Вернуться к версии {version}",
+    "core_rollback_confirm": "Текущая версия ядра будет заменена на {version}. Пользовательские списки и настройки будут сохранены.",
+    "core_rollback_success": "Откат ядра успешно выполнен.",
     "title": "Zapret_ VPN",
     "nav_home": "Главная",
     "nav_sites": "Списки сайтов",


### PR DESCRIPTION
### Motivation
- Introduce a safe, atomic installation workflow for the Zapret core that supports staged installs, checksum verification, atomic manifests, automatic recovery from interrupted operations, and explicit rollback semantics.
- Expose installation state and rollback actions to the UI so users can view current/previous core versions and perform a controlled rollback.

### Description
- Adds a new core installation module `src-tauri/src/core/installation.rs` implementing `CoreManifest`, `CoreInstallation`, staging creation, validation, atomic manifest writes, activation, rollback, and multiple recovery paths for interrupted operations; includes comprehensive unit tests for these flows.
- Extends `CoreProvider` (in `provider.rs`) with `provider_name()` and `validate_installation()` and makes `Checksum` serializable to persist checksums in manifests; implements these for the Flowseal provider (`providers/flowseal.rs`).
- Integrates the new installation lifecycle into the application flow (`src-tauri/src/lib.rs`) by: adding an operation guard to prevent overlapping core operations, introducing `OwnedDirectoryCleanup` RAII cleanup for owned temp directories, capturing restart context to safely stop/restart Zapret around activation/rollback, wiring download/extract/manifest/activate flow to use staging and verified checksums, and adding Tauri commands `get_core_installation_state` and `rollback_core_update`.
- Adds frontend UI elements and wiring to display core current/previous versions and to trigger rollbacks (`src/components/sections/settings.html`, `src/features/updates.js`), and corresponding i18n entries for English and Russian (`src/i18n/en.js`, `src/i18n/ru.js`).
- Updates `.gitignore` to treat `binaries/` and related transient staging/backup directories as local artifacts and removes the committed `.gitkeep` used previously.

### Testing
- New unit tests in `src-tauri/src/core/installation.rs` and temporary-cleanup tests under the same module were added and executed as part of `cargo test` for the tauri backend, and they passed.
- Ran `cargo test` for the tauri crate to validate installation, activation, rollback, recovery, manifest round-trips, and cleanup behaviors; all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65e4095798833091863fe19bcb4ec8)