### PR TITLE
Add managed stable core release channel

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,11 +29,15 @@ jobs:
           workspaces: "src-tauri"
           shared-key: "zapret-ui-rust-cache-clippy"
 
+      - name: cargo test
+        working-directory: src-tauri
+        run: cargo test
+
       - name: cargo clippy
         working-directory: src-tauri
-        # Blocking: all pre-existing warnings have been cleaned up, so any new
-        # finding must be addressed in the PR that introduces it.
-        run: cargo clippy --no-deps -- -D warnings
+        # Blocking: check library, binaries, and test targets so test-only
+        # feature/configuration mistakes cannot bypass CI.
+        run: cargo clippy --all-targets --no-deps -- -D warnings
 
   cargo-audit:
     # cargo-audit is pure crate-metadata analysis, so we can run it on Linux

--- a/core-channel/stable.json
+++ b/core-channel/stable.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "channel": "stable",
+  "provider": "flowseal",
+  "version": "",
+  "artifacts": []
+}

--- a/docs/core-release-channel.md
+++ b/docs/core-release-channel.md
@@ -1,0 +1,14 @@
+# Managed stable core channel
+
+Core updates are controlled by `core-channel/stable.json`; the application never promotes an upstream Flowseal release automatically. The checked-in manifest is also the offline fallback embedded at compile time.
+
+## Promotion
+
+1. Select a Flowseal release candidate and test it manually on Windows.
+2. Run `npm run promote-core-stable -- --version <version> --url <https-url> [--url <mirror>]`.
+3. The script downloads every exact artifact byte stream and calculates its SHA-256. It rejects HTTP and writes the manifest atomically.
+4. Review the `stable.json` diff, including every URL, version, and checksum.
+5. Open a separate pull request containing the manifest promotion. The script deliberately does not commit, push, merge, or publish.
+6. Once merged to `main`, clients receive the approved version without a new application release. Builds retain that manifest as their last-known-good offline fallback.
+
+The initial placeholder manifest intentionally contains no release. The execution environment used to add the channel could not reach GitHub, so no unverifiable production version or checksum was invented. A maintainer must run the promotion command in a networked environment before releasing this build.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "zapret-ui",
       "version": "26.7.5",
-      "dependencies": {
-        "@tailwindcss/oxide-win32-x64-msvc": "^4.3.3"
-      },
       "devDependencies": {
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/vite": "^4.3.3",
@@ -18,6 +15,9 @@
         "postcss": "^8.5.23",
         "tailwindcss": "^4.3.3",
         "vite": "^8.1.5"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-win32-x64-msvc": "^4.3.3"
       }
     },
     "node_modules/@emnapi/core": {
@@ -727,7 +727,8 @@
       ],
       "engines": {
         "node": ">= 20"
-      }
+      },
+      "optional": true
     },
     "node_modules/@tailwindcss/vite": {
       "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "check-versions": "node scripts/check-versions.mjs",
-    "set-version": "node scripts/set-version.mjs"
+    "set-version": "node scripts/set-version.mjs",
+    "promote-core-stable": "node scripts/promote-core-stable.mjs"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.11",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tailwindcss": "^4.3.3",
     "vite": "^8.1.5"
   },
-  "dependencies": {
+  "optionalDependencies": {
     "@tailwindcss/oxide-win32-x64-msvc": "^4.3.3"
   }
 }

--- a/scripts/promote-core-stable.mjs
+++ b/scripts/promote-core-stable.mjs
@@ -1,0 +1,33 @@
+import { createHash } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { rename, rm } from 'node:fs/promises';
+import { Readable, Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import path from 'node:path';
+
+const args = process.argv.slice(2);
+let version;
+const urls = [];
+for (let i = 0; i < args.length; i += 2) {
+  if (args[i] === '--version') version = args[i + 1];
+  else if (args[i] === '--url') urls.push(args[i + 1]);
+  else throw new Error(`Unknown argument: ${args[i]}`);
+}
+if (!version?.trim() || urls.length === 0) throw new Error('Usage: --version <version> --url <https-url> [--url <https-url>]');
+for (const value of urls) if (new URL(value).protocol !== 'https:') throw new Error(`Only HTTPS artifacts are allowed: ${value}`);
+
+const artifacts = [];
+for (const url of urls) {
+  const response = await fetch(url, { redirect: 'follow' });
+  if (!response.ok || !response.body) throw new Error(`Download failed (${response.status}): ${url}`);
+  const hash = createHash('sha256');
+  await pipeline(Readable.fromWeb(response.body), new Transform({ transform(chunk, _encoding, callback) { hash.update(chunk); callback(); } }));
+  artifacts.push({ url, checksum: { algorithm: 'sha256', value: hash.digest('hex') } });
+}
+const target = path.resolve('core-channel/stable.json');
+const temporary = `${target}.tmp-${process.pid}`;
+try {
+  await pipeline(Readable.from(`${JSON.stringify({ schemaVersion: 1, channel: 'stable', provider: 'flowseal', version, artifacts }, null, 2)}\n`), createWriteStream(temporary, { flags: 'wx' }));
+  await rename(temporary, target);
+} finally { await rm(temporary, { force: true }); }
+console.log(`Promoted Flowseal ${version} with ${artifacts.length} verified artifact(s). Review the diff before committing.`);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4568,7 +4568,18 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2331,12 +2331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
-
-[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5880,7 +5874,6 @@ version = "26.7.5"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
- "md5",
  "reqwest",
  "rfd",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,9 @@ zip = { version = "8", default-features = false, features = ["deflate", "deflate
 rfd = "0.15"
 tokio = { version = "1", features = ["net", "time"] }
 
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
+
 [[bin]]
 name = "zapret-ui"
 path = "src/main.rs"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,6 @@ sha2 = "0.11"
 base64 = "0.22"
 zip = { version = "8", default-features = false, features = ["deflate", "deflate-flate2", "bzip2"] }
 rfd = "0.15"
-md5 = "0.7"
 tokio = { version = "1", features = ["net", "time"] }
 
 [[bin]]

--- a/src-tauri/src/core/channel.rs
+++ b/src-tauri/src/core/channel.rs
@@ -114,7 +114,7 @@ where
         if body.len().saturating_add(chunk.len()) > MAX_MANIFEST_BYTES {
             return Err("channel response is too large".into());
         }
-        body.extend_from_slice(&chunk);
+        body.extend_from_slice(chunk);
     }
     Ok(body)
 }

--- a/src-tauri/src/core/channel.rs
+++ b/src-tauri/src/core/channel.rs
@@ -233,7 +233,7 @@ mod tests {
             "1.2.3"
         );
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn streaming_limit_stops_oversized_body() {
         let chunks = futures_util::stream::iter([
             Ok::<_, String>(vec![0; MAX_MANIFEST_BYTES]),

--- a/src-tauri/src/core/channel.rs
+++ b/src-tauri/src/core/channel.rs
@@ -1,0 +1,202 @@
+use reqwest::header::{CACHE_CONTROL, USER_AGENT};
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+
+const PRODUCTION_URL: &str =
+    "https://raw.githubusercontent.com/larrriiin/zapret-ui/main/core-channel/stable.json";
+const MAX_MANIFEST_BYTES: usize = 256 * 1024;
+const EMBEDDED: &str = include_str!("../../../core-channel/stable.json");
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct StableManifest {
+    pub schema_version: u32,
+    pub channel: String,
+    pub provider: String,
+    pub version: String,
+    pub artifacts: Vec<Artifact>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Artifact {
+    pub url: String,
+    pub checksum: ArtifactChecksum,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactChecksum {
+    pub algorithm: String,
+    pub value: String,
+}
+
+impl StableManifest {
+    pub fn parse_and_validate(bytes: &[u8], provider: &str) -> Result<Self, String> {
+        if bytes.len() > MAX_MANIFEST_BYTES {
+            return Err("channel manifest exceeds 256 KiB".into());
+        }
+        let value: Self = serde_json::from_slice(bytes)
+            .map_err(|_| "channel manifest is not valid schema v1 JSON".to_string())?;
+        if value.schema_version != 1 {
+            return Err(format!(
+                "unsupported channel schema {}",
+                value.schema_version
+            ));
+        }
+        if value.channel != "stable" {
+            return Err("channel must be stable".into());
+        }
+        if value.provider != provider {
+            return Err("channel provider does not match the installed provider".into());
+        }
+        if value.version.trim().is_empty() {
+            return Err("channel version is empty".into());
+        }
+        if value.artifacts.is_empty() {
+            return Err("stable channel contains no artifacts".into());
+        }
+        for artifact in &value.artifacts {
+            let url = reqwest::Url::parse(&artifact.url)
+                .map_err(|_| "artifact URL is invalid".to_string())?;
+            if url.scheme() != "https" {
+                return Err("stable artifacts must use HTTPS".into());
+            }
+            if artifact.checksum.algorithm != "sha256" {
+                return Err("stable artifacts require SHA-256".into());
+            }
+            let digest = &artifact.checksum.value;
+            if digest.len() != 64 || !digest.bytes().all(|b| b.is_ascii_hexdigit()) {
+                return Err("SHA-256 must contain exactly 64 hexadecimal characters".into());
+            }
+            if digest.bytes().any(|b| b.is_ascii_uppercase()) {
+                return Err("SHA-256 must be lowercase".into());
+            }
+        }
+        Ok(value)
+    }
+}
+
+fn channel_url() -> String {
+    #[cfg(debug_assertions)]
+    if let Ok(value) = std::env::var("ZAPRET_CORE_CHANNEL_URL") {
+        return value;
+    }
+    PRODUCTION_URL.to_string()
+}
+
+pub async fn resolve_stable(
+    client: &reqwest::Client,
+    provider: &str,
+    user_agent: &str,
+) -> Result<StableManifest, String> {
+    let remote = async {
+        let response = client
+            .get(channel_url())
+            .header(CACHE_CONTROL, "no-cache")
+            .header(USER_AGENT, user_agent)
+            .send()
+            .await
+            .map_err(|_| "channel request failed")?;
+        if !response.status().is_success() {
+            return Err("channel returned an HTTP error");
+        }
+        if response
+            .content_length()
+            .is_some_and(|n| n > MAX_MANIFEST_BYTES as u64)
+        {
+            return Err("channel response is too large");
+        }
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|_| "channel response could not be read")?;
+        StableManifest::parse_and_validate(&bytes, provider)
+            .map_err(|_| "remote channel validation failed")
+    }
+    .await;
+    match remote {
+        Ok(value) => Ok(value),
+        Err(reason) => {
+            eprintln!("Stable core channel fallback: {reason}");
+            StableManifest::parse_and_validate(EMBEDDED.as_bytes(), provider)
+                .map_err(|_| "Stable core channel is temporarily unavailable".to_string())
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CoreUpdateStatus {
+    NotInstalled,
+    UpdateAvailable,
+    UpToDate,
+    Ahead,
+    Unknown,
+}
+
+pub fn compare_versions(local: &str, stable: &str) -> CoreUpdateStatus {
+    fn parse(s: &str) -> Option<Vec<u64>> {
+        let s = s.trim().strip_prefix('v').unwrap_or(s.trim());
+        let parts: Option<Vec<_>> = s.split('.').map(|p| p.parse().ok()).collect();
+        parts.filter(|p| p.len() >= 2 && p.len() <= 4)
+    }
+    match (parse(local), parse(stable)) {
+        (Some(a), Some(b)) => match a.cmp(&b) {
+            Ordering::Less => CoreUpdateStatus::UpdateAvailable,
+            Ordering::Equal => CoreUpdateStatus::UpToDate,
+            Ordering::Greater => CoreUpdateStatus::Ahead,
+        },
+        _ => CoreUpdateStatus::Unknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn json(overrides: &str) -> Vec<u8> {
+        format!(r#"{{"schemaVersion":1,"channel":"stable","provider":"flowseal","version":"1.2.3","artifacts":[{{"url":"https://example.invalid/a.zip","checksum":{{"algorithm":"sha256","value":"{}"}}}}]{} }}"#, "a".repeat(64), overrides).into_bytes()
+    }
+    #[test]
+    fn valid_v1() {
+        StableManifest::parse_and_validate(&json(""), "flowseal").unwrap();
+    }
+    #[test]
+    fn comparisons() {
+        assert_eq!(
+            compare_versions("1.2.2", "1.2.3"),
+            CoreUpdateStatus::UpdateAvailable
+        );
+        assert_eq!(
+            compare_versions("1.2.3", "1.2.3"),
+            CoreUpdateStatus::UpToDate
+        );
+        assert_eq!(compare_versions("1.3.0", "1.2.3"), CoreUpdateStatus::Ahead);
+        assert_eq!(compare_versions("Err", "1.2.3"), CoreUpdateStatus::Unknown);
+    }
+    #[test]
+    fn rejects_invalid_fields() {
+        for (from, to) in [
+            ("\"schemaVersion\":1", "\"schemaVersion\":2"),
+            ("\"channel\":\"stable\"", "\"channel\":\"beta\""),
+            ("\"provider\":\"flowseal\"", "\"provider\":\"other\""),
+            ("\"version\":\"1.2.3\"", "\"version\":\"\""),
+            ("https://example.invalid", "http://example.invalid"),
+            ("\"algorithm\":\"sha256\"", "\"algorithm\":\"md5\""),
+        ] {
+            let s = String::from_utf8(json("")).unwrap().replace(from, to);
+            assert!(StableManifest::parse_and_validate(s.as_bytes(), "flowseal").is_err());
+        }
+        let empty=String::from_utf8(json("")).unwrap().replace(r#"[{"url"# , r#"_EMPTY_[{"url"#).replace(r#""artifacts":_EMPTY_[{"url":"https://example.invalid/a.zip","checksum":{"algorithm":"sha256","value":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}]"#, r#""artifacts":[]"#);
+        assert!(StableManifest::parse_and_validate(empty.as_bytes(), "flowseal").is_err());
+        for digest in [
+            "abc",
+            "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
+        ] {
+            let s = String::from_utf8(json(""))
+                .unwrap()
+                .replace(&"a".repeat(64), digest);
+            assert!(StableManifest::parse_and_validate(s.as_bytes(), "flowseal").is_err());
+        }
+    }
+}

--- a/src-tauri/src/core/channel.rs
+++ b/src-tauri/src/core/channel.rs
@@ -1,38 +1,41 @@
+use futures_util::{Stream, StreamExt};
 use reqwest::header::{CACHE_CONTROL, USER_AGENT};
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
+use std::{cmp::Ordering, pin::Pin};
+
+use super::{Checksum, CoreArtifact, CoreRelease};
 
 const PRODUCTION_URL: &str =
     "https://raw.githubusercontent.com/larrriiin/zapret-ui/main/core-channel/stable.json";
 const MAX_MANIFEST_BYTES: usize = 256 * 1024;
 const EMBEDDED: &str = include_str!("../../../core-channel/stable.json");
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct StableManifest {
-    pub schema_version: u32,
-    pub channel: String,
-    pub provider: String,
-    pub version: String,
-    pub artifacts: Vec<Artifact>,
+struct StableManifest {
+    schema_version: u32,
+    channel: String,
+    provider: String,
+    version: String,
+    artifacts: Vec<ManifestArtifact>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub struct Artifact {
-    pub url: String,
-    pub checksum: ArtifactChecksum,
+struct ManifestArtifact {
+    url: String,
+    checksum: ManifestChecksum,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub struct ArtifactChecksum {
-    pub algorithm: String,
-    pub value: String,
+struct ManifestChecksum {
+    algorithm: String,
+    value: String,
 }
 
 impl StableManifest {
-    pub fn parse_and_validate(bytes: &[u8], provider: &str) -> Result<Self, String> {
+    fn parse_and_validate(bytes: &[u8], provider: &str) -> Result<CoreRelease, String> {
         if bytes.len() > MAX_MANIFEST_BYTES {
             return Err("channel manifest exceeds 256 KiB".into());
         }
@@ -56,24 +59,37 @@ impl StableManifest {
         if value.artifacts.is_empty() {
             return Err("stable channel contains no artifacts".into());
         }
-        for artifact in &value.artifacts {
-            let url = reqwest::Url::parse(&artifact.url)
-                .map_err(|_| "artifact URL is invalid".to_string())?;
-            if url.scheme() != "https" {
-                return Err("stable artifacts must use HTTPS".into());
-            }
-            if artifact.checksum.algorithm != "sha256" {
-                return Err("stable artifacts require SHA-256".into());
-            }
-            let digest = &artifact.checksum.value;
-            if digest.len() != 64 || !digest.bytes().all(|b| b.is_ascii_hexdigit()) {
-                return Err("SHA-256 must contain exactly 64 hexadecimal characters".into());
-            }
-            if digest.bytes().any(|b| b.is_ascii_uppercase()) {
-                return Err("SHA-256 must be lowercase".into());
-            }
-        }
-        Ok(value)
+        let artifacts = value
+            .artifacts
+            .into_iter()
+            .map(|artifact| {
+                let url = reqwest::Url::parse(&artifact.url)
+                    .map_err(|_| "artifact URL is invalid".to_string())?;
+                if url.scheme() != "https" {
+                    return Err("stable artifacts must use HTTPS".into());
+                }
+                if artifact.checksum.algorithm != "sha256" {
+                    return Err("stable artifacts require SHA-256".into());
+                }
+                let digest = artifact.checksum.value;
+                if digest.len() != 64 || !digest.bytes().all(|b| b.is_ascii_hexdigit()) {
+                    return Err("SHA-256 must contain exactly 64 hexadecimal characters".into());
+                }
+                if digest.bytes().any(|b| b.is_ascii_uppercase()) {
+                    return Err("SHA-256 must be lowercase".into());
+                }
+                Ok(CoreArtifact {
+                    url: artifact.url,
+                    checksum: Checksum::Sha256(digest),
+                })
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        Ok(CoreRelease {
+            provider: value.provider,
+            channel: value.channel,
+            version: value.version,
+            artifacts,
+        })
     }
 }
 
@@ -85,11 +101,44 @@ fn channel_url() -> String {
     PRODUCTION_URL.to_string()
 }
 
+async fn collect_limited<S, B, E>(mut stream: Pin<Box<S>>) -> Result<Vec<u8>, String>
+where
+    S: Stream<Item = Result<B, E>> + ?Sized,
+    B: AsRef<[u8]>,
+    E: std::fmt::Display,
+{
+    let mut body = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("channel response could not be read: {e}"))?;
+        let chunk = chunk.as_ref();
+        if body.len().saturating_add(chunk.len()) > MAX_MANIFEST_BYTES {
+            return Err("channel response is too large".into());
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+fn resolve_bytes(
+    remote: Result<Vec<u8>, String>,
+    embedded: &[u8],
+    provider: &str,
+) -> Result<CoreRelease, String> {
+    match remote.and_then(|bytes| StableManifest::parse_and_validate(&bytes, provider)) {
+        Ok(release) => Ok(release),
+        Err(reason) => {
+            eprintln!("Stable core channel fallback: {reason}");
+            StableManifest::parse_and_validate(embedded, provider)
+                .map_err(|_| "Stable core channel is temporarily unavailable".to_string())
+        }
+    }
+}
+
 pub async fn resolve_stable(
     client: &reqwest::Client,
     provider: &str,
     user_agent: &str,
-) -> Result<StableManifest, String> {
+) -> Result<CoreRelease, String> {
     let remote = async {
         let response = client
             .get(channel_url())
@@ -97,32 +146,20 @@ pub async fn resolve_stable(
             .header(USER_AGENT, user_agent)
             .send()
             .await
-            .map_err(|_| "channel request failed")?;
+            .map_err(|_| "channel request failed".to_string())?;
         if !response.status().is_success() {
-            return Err("channel returned an HTTP error");
+            return Err("channel returned an HTTP error".into());
         }
         if response
             .content_length()
             .is_some_and(|n| n > MAX_MANIFEST_BYTES as u64)
         {
-            return Err("channel response is too large");
+            return Err("channel response is too large".into());
         }
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|_| "channel response could not be read")?;
-        StableManifest::parse_and_validate(&bytes, provider)
-            .map_err(|_| "remote channel validation failed")
+        collect_limited(Box::pin(response.bytes_stream())).await
     }
     .await;
-    match remote {
-        Ok(value) => Ok(value),
-        Err(reason) => {
-            eprintln!("Stable core channel fallback: {reason}");
-            StableManifest::parse_and_validate(EMBEDDED.as_bytes(), provider)
-                .map_err(|_| "Stable core channel is temporarily unavailable".to_string())
-        }
-    }
+    resolve_bytes(remote, EMBEDDED.as_bytes(), provider)
 }
 
 #[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
@@ -138,8 +175,18 @@ pub enum CoreUpdateStatus {
 pub fn compare_versions(local: &str, stable: &str) -> CoreUpdateStatus {
     fn parse(s: &str) -> Option<Vec<u64>> {
         let s = s.trim().strip_prefix('v').unwrap_or(s.trim());
-        let parts: Option<Vec<_>> = s.split('.').map(|p| p.parse().ok()).collect();
-        parts.filter(|p| p.len() >= 2 && p.len() <= 4)
+        let mut parts: Vec<u64> = s
+            .split('.')
+            .map(str::parse)
+            .collect::<Result<_, _>>()
+            .ok()?;
+        if !(2..=4).contains(&parts.len()) {
+            return None;
+        }
+        while parts.last() == Some(&0) {
+            parts.pop();
+        }
+        Some(parts)
     }
     match (parse(local), parse(stable)) {
         (Some(a), Some(b)) => match a.cmp(&b) {
@@ -154,25 +201,48 @@ pub fn compare_versions(local: &str, stable: &str) -> CoreUpdateStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
-    fn json(overrides: &str) -> Vec<u8> {
-        format!(r#"{{"schemaVersion":1,"channel":"stable","provider":"flowseal","version":"1.2.3","artifacts":[{{"url":"https://example.invalid/a.zip","checksum":{{"algorithm":"sha256","value":"{}"}}}}]{} }}"#, "a".repeat(64), overrides).into_bytes()
+    fn valid() -> Vec<u8> {
+        format!(r#"{{"schemaVersion":1,"channel":"stable","provider":"flowseal","version":"1.2.3","artifacts":[{{"url":"https://example.invalid/a.zip","checksum":{{"algorithm":"sha256","value":"{}"}}}}]}}"#, "a".repeat(64)).into_bytes()
     }
     #[test]
     fn valid_v1() {
-        StableManifest::parse_and_validate(&json(""), "flowseal").unwrap();
+        StableManifest::parse_and_validate(&valid(), "flowseal").unwrap();
     }
     #[test]
-    fn comparisons() {
+    fn comparisons_normalize_zero_components() {
         assert_eq!(
             compare_versions("1.2.2", "1.2.3"),
             CoreUpdateStatus::UpdateAvailable
         );
-        assert_eq!(
-            compare_versions("1.2.3", "1.2.3"),
-            CoreUpdateStatus::UpToDate
-        );
+        assert_eq!(compare_versions("1.2", "1.2.0"), CoreUpdateStatus::UpToDate);
         assert_eq!(compare_versions("1.3.0", "1.2.3"), CoreUpdateStatus::Ahead);
         assert_eq!(compare_versions("Err", "1.2.3"), CoreUpdateStatus::Unknown);
+    }
+    #[test]
+    fn remote_error_and_invalid_remote_use_embedded() {
+        assert_eq!(
+            resolve_bytes(Err("offline".into()), &valid(), "flowseal")
+                .unwrap()
+                .version,
+            "1.2.3"
+        );
+        assert_eq!(
+            resolve_bytes(Ok(b"not json".to_vec()), &valid(), "flowseal")
+                .unwrap()
+                .version,
+            "1.2.3"
+        );
+    }
+    #[tokio::test]
+    async fn streaming_limit_stops_oversized_body() {
+        let chunks = futures_util::stream::iter([
+            Ok::<_, String>(vec![0; MAX_MANIFEST_BYTES]),
+            Ok(vec![b'x']),
+        ]);
+        assert!(collect_limited(Box::pin(chunks))
+            .await
+            .unwrap_err()
+            .contains("too large"));
     }
     #[test]
     fn rejects_invalid_fields() {
@@ -184,19 +254,21 @@ mod tests {
             ("https://example.invalid", "http://example.invalid"),
             ("\"algorithm\":\"sha256\"", "\"algorithm\":\"md5\""),
         ] {
-            let s = String::from_utf8(json("")).unwrap().replace(from, to);
-            assert!(StableManifest::parse_and_validate(s.as_bytes(), "flowseal").is_err());
+            let body = String::from_utf8(valid()).unwrap().replace(from, to);
+            assert!(StableManifest::parse_and_validate(body.as_bytes(), "flowseal").is_err());
         }
-        let empty=String::from_utf8(json("")).unwrap().replace(r#"[{"url"# , r#"_EMPTY_[{"url"#).replace(r#""artifacts":_EMPTY_[{"url":"https://example.invalid/a.zip","checksum":{"algorithm":"sha256","value":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}]"#, r#""artifacts":[]"#);
-        assert!(StableManifest::parse_and_validate(empty.as_bytes(), "flowseal").is_err());
+        let empty = serde_json::json!({"schemaVersion":1,"channel":"stable","provider":"flowseal","version":"1.2.3","artifacts":[]});
+        assert!(
+            StableManifest::parse_and_validate(empty.to_string().as_bytes(), "flowseal").is_err()
+        );
         for digest in [
             "abc",
             "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
         ] {
-            let s = String::from_utf8(json(""))
+            let body = String::from_utf8(valid())
                 .unwrap()
                 .replace(&"a".repeat(64), digest);
-            assert!(StableManifest::parse_and_validate(s.as_bytes(), "flowseal").is_err());
+            assert!(StableManifest::parse_and_validate(body.as_bytes(), "flowseal").is_err());
         }
     }
 }

--- a/src-tauri/src/core/installation.rs
+++ b/src-tauri/src/core/installation.rs
@@ -25,6 +25,8 @@ const ACTIVE_FAKE_FILES: [&str; 2] = ["ACTIVE_DISCORD_UDP.bin", "ACTIVE_GAME_UDP
 pub struct CoreManifest {
     pub schema_version: u32,
     pub provider: String,
+    #[serde(default)]
+    pub channel: Option<String>,
     pub version: String,
     pub source_url: Option<String>,
     pub checksum: Option<Checksum>,
@@ -45,6 +47,7 @@ impl CoreManifest {
         Self {
             schema_version: SCHEMA_VERSION,
             provider,
+            channel: None,
             version,
             source_url,
             checksum,
@@ -241,8 +244,22 @@ impl CoreInstallation {
     ) -> Result<(), String> {
         self.assert_staging(staging)?;
         CoreManifest::read(staging)?;
-        if !self.active.is_dir() {
-            return Err("Active core is missing".into());
+        if !self.active.exists() {
+            if self.previous.exists() {
+                return Err("Cannot perform first activation while a previous core exists".into());
+            }
+            fs::rename(staging, &self.active)
+                .map_err(|e| format!("Cannot activate first core: {e}"))?;
+            if let Err(error) = active_provider.validate_installation() {
+                self.assert_owned(&self.active, "binaries")?;
+                fs::remove_dir_all(&self.active).map_err(|cleanup| {
+                    format!(
+                        "Post-activation validation failed ({error}); cleanup failed: {cleanup}"
+                    )
+                })?;
+                return Err(format!("Post-activation validation failed: {error}"));
+            }
+            return Ok(());
         }
         self.preserve_user_files(&self.active, staging)?;
         let previous_backup = self.parent.join(PREVIOUS_BACKUP_NAME);
@@ -791,6 +808,45 @@ mod tests {
         assert_eq!(CoreManifest::read(&active).unwrap().version, "2.0.0");
         assert_eq!(CoreManifest::read(&previous).unwrap().version, "1.0.0");
         assert!(!temp.0.join(PREVIOUS_BACKUP_NAME).exists());
+    }
+
+    #[test]
+    fn successful_first_install_has_no_rollback() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let installation = CoreInstallation::new(&active).unwrap();
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        installation
+            .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+            .unwrap();
+        installation.activate(&staging, provider(&active)).unwrap();
+        assert_eq!(CoreManifest::read(&active).unwrap().version, "2.0.0");
+        assert!(!installation.state().rollback_available);
+        assert!(installation
+            .rollback(provider(&active), provider(&active))
+            .is_err());
+        installation.recover().unwrap();
+        installation.recover().unwrap();
+        assert!(active.exists());
+    }
+
+    #[test]
+    fn failed_first_install_leaves_no_partial_active_core() {
+        let temp = Temp::new();
+        let active = temp.0.join("binaries");
+        let installation = CoreInstallation::new(&active).unwrap();
+        let staging = installation.create_staging().unwrap();
+        fixture(&staging, "2.0.0");
+        installation
+            .validate_and_manifest(&staging, "2.0.0", None, None, provider(&staging))
+            .unwrap();
+        fs::remove_file(staging.join("service.bat")).unwrap();
+        assert!(installation.activate(&staging, provider(&active)).is_err());
+        assert!(!active.exists());
+        installation.recover().unwrap();
+        installation.recover().unwrap();
+        assert!(!active.exists());
     }
 
     #[test]

--- a/src-tauri/src/core/manager.rs
+++ b/src-tauri/src/core/manager.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use crate::providers::FlowsealProvider;
 
-use super::{CoreProvider, CoreRelease};
+use super::CoreProvider;
 
 /// Composition root for the active core. Flowseal is selected here only; UI
 /// and Tauri command orchestration depend on the provider-neutral interface.
@@ -19,16 +19,5 @@ impl CoreManager {
 
     pub fn provider(&self) -> &dyn CoreProvider {
         &self.provider
-    }
-
-    pub async fn fetch_fallback_release(
-        &self,
-        client: &reqwest::Client,
-    ) -> Result<CoreRelease, String> {
-        self.provider.fetch_fallback_release(client).await
-    }
-
-    pub fn fallback_latest_url(&self) -> &'static str {
-        self.provider.fallback_latest_url()
     }
 }

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -4,8 +4,8 @@ mod manager;
 mod paths;
 mod provider;
 
-pub use channel::{compare_versions, resolve_stable, CoreUpdateStatus, StableManifest};
+pub use channel::{compare_versions, resolve_stable, CoreUpdateStatus};
 pub use installation::{CoreInstallation, CoreInstallationState, CoreManifest};
 pub use manager::CoreManager;
 pub use paths::CorePaths;
-pub use provider::{Checksum, CoreProvider};
+pub use provider::{Checksum, CoreArtifact, CoreProvider, CoreRelease};

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -1,9 +1,11 @@
+mod channel;
 mod installation;
 mod manager;
 mod paths;
 mod provider;
 
-pub use installation::{CoreInstallation, CoreInstallationState};
+pub use channel::{compare_versions, resolve_stable, CoreUpdateStatus, StableManifest};
+pub use installation::{CoreInstallation, CoreInstallationState, CoreManifest};
 pub use manager::CoreManager;
 pub use paths::CorePaths;
-pub use provider::{Checksum, CoreProvider, CoreRelease};
+pub use provider::{Checksum, CoreProvider};

--- a/src-tauri/src/core/provider.rs
+++ b/src-tauri/src/core/provider.rs
@@ -12,20 +12,24 @@ pub enum Checksum {
 
 /// Download information without assumptions about a provider's hosting service.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub struct CoreArtifact {
+    pub url: String,
+    pub checksum: Checksum,
+}
+
+#[allow(dead_code)]
 pub struct CoreRelease {
+    pub provider: String,
+    pub channel: String,
     pub version: String,
-    pub download_url: String,
-    pub checksum: Option<Checksum>,
+    pub artifacts: Vec<CoreArtifact>,
 }
 
 /// Boundary between Tauri/core orchestration and an upstream core distribution.
 pub trait CoreProvider: Send + Sync {
     fn provider_name(&self) -> &'static str;
     fn paths(&self) -> &CorePaths;
-    fn version_url(&self) -> &'static str;
-    fn release_api_url(&self, version: &str) -> String;
-    fn archive_name(&self, version: &str) -> String;
-    fn release_download_url(&self, version: &str) -> String;
     fn ipset_url(&self) -> &'static str;
     fn service_script(&self) -> PathBuf;
     fn test_script(&self) -> PathBuf;

--- a/src-tauri/src/core/provider.rs
+++ b/src-tauri/src/core/provider.rs
@@ -7,18 +7,19 @@ use super::CorePaths;
 #[serde(tag = "algorithm", content = "value", rename_all = "lowercase")]
 pub enum Checksum {
     Sha256(String),
+    // Kept only to deserialize schema-v1 installation manifests created by
+    // the former SourceForge updater. Managed channel artifacts never create it.
     Md5(String),
 }
 
 /// Download information without assumptions about a provider's hosting service.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[allow(dead_code)]
 pub struct CoreArtifact {
     pub url: String,
     pub checksum: Checksum,
 }
 
-#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CoreRelease {
     pub provider: String,
     pub channel: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,7 +33,10 @@ use tauri_plugin_notification::NotificationExt;
 
 mod core;
 mod providers;
-use core::{Checksum, CoreInstallation, CoreInstallationState, CoreManager, CoreRelease};
+use core::{
+    compare_versions, resolve_stable, Checksum, CoreInstallation, CoreInstallationState,
+    CoreManager, CoreUpdateStatus,
+};
 
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 const GITHUB_USER_AGENT: &str = "zapret-ui-updater";
@@ -382,92 +385,6 @@ fn hex_encode(bytes: &[u8]) -> String {
 
 /// Fetches the expected SHA-256 digest of the given release asset from the
 /// GitHub Releases API. Returns a lowercase hex string on success.
-async fn fetch_expected_sha256(version: &str, asset_name: &str) -> Result<String, String> {
-    if version.is_empty()
-        || !version
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | '+'))
-    {
-        return Err(format!("Invalid upstream version tag: {}", version));
-    }
-
-    let url = core_manager().provider().release_api_url(version);
-    let client = reqwest::Client::builder()
-        .user_agent(GITHUB_USER_AGENT)
-        .build()
-        .map_err(|e| format!("Failed to build HTTP client: {}", e))?;
-
-    let resp = client
-        .get(&url)
-        .header("Accept", "application/vnd.github+json")
-        .send()
-        .await
-        .map_err(|e| format!("Failed to fetch release metadata: {}", e))?;
-
-    if !resp.status().is_success() {
-        return Err(format!(
-            "GitHub API returned status {} for {}",
-            resp.status(),
-            url
-        ));
-    }
-
-    let body: serde_json::Value = resp
-        .json()
-        .await
-        .map_err(|e| format!("Failed to parse release metadata: {}", e))?;
-
-    let assets = body
-        .get("assets")
-        .and_then(|a| a.as_array())
-        .ok_or_else(|| "Release metadata is missing assets".to_string())?;
-
-    let asset = assets
-        .iter()
-        .find(|a| a.get("name").and_then(|n| n.as_str()) == Some(asset_name))
-        .ok_or_else(|| format!("Asset {} not found in release {}", asset_name, version))?;
-
-    let digest = asset
-        .get("digest")
-        .and_then(|d| d.as_str())
-        .ok_or_else(|| format!("Asset {} has no digest field", asset_name))?;
-
-    let hex = digest
-        .strip_prefix("sha256:")
-        .ok_or_else(|| format!("Unsupported digest format: {}", digest))?;
-
-    if hex.len() != 64 || !hex.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err(format!("Malformed sha256 digest: {}", digest));
-    }
-
-    Ok(hex.to_ascii_lowercase())
-}
-
-pub async fn fetch_fallback_release_info(client: &reqwest::Client) -> Result<CoreRelease, String> {
-    core_manager().fetch_fallback_release(client).await
-}
-
-/// Computes the MD5 digest of a file as a lowercase hex string.
-pub fn md5_file(path: &std::path::Path) -> Result<String, String> {
-    use std::io::Read;
-
-    let mut file = std::fs::File::open(path)
-        .map_err(|e| format!("Failed to open {}: {}", path.display(), e))?;
-    let mut context = md5::Context::new();
-    let mut buf = [0u8; 64 * 1024];
-    loop {
-        let n = file
-            .read(&mut buf)
-            .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
-        if n == 0 {
-            break;
-        }
-        context.consume(&buf[..n]);
-    }
-    let digest = context.compute();
-    Ok(format!("{:x}", digest))
-}
-
 /// On Windows, `std::fs::canonicalize` returns the verbatim/extended-length
 /// form (e.g. `\\?\C:\foo\bar`). That form is fine for Rust's file APIs but
 /// breaks `cmd.exe` and downstream `.bat` scripts, which refuse to use it as
@@ -649,40 +566,50 @@ async fn get_remote_core_version(
 
     let client = client_builder.build().map_err(|e| e.to_string())?;
 
-    let response_res = client
-        .get(core_manager().provider().version_url())
-        .send()
-        .await;
+    Ok(resolve_stable(
+        &client,
+        core_manager().provider().provider_name(),
+        GITHUB_USER_AGENT,
+    )
+    .await?
+    .version)
+}
 
-    match response_res {
-        Ok(resp) => {
-            let status = resp.status();
-            if status.is_success() {
-                if let Ok(text) = resp.text().await {
-                    let trimmed = text.trim();
-                    if !trimmed.is_empty() && !trimmed.contains("Not Found") {
-                        return Ok(trimmed.to_string());
-                    }
-                }
-            }
-            if let Ok(info) = fetch_fallback_release_info(&client).await {
-                return Ok(info.version);
-            }
-            Err(format!(
-                "GitHub returned status {} and SourceForge fallback failed",
-                status
-            ))
-        }
-        Err(e) => {
-            if let Ok(info) = fetch_fallback_release_info(&client).await {
-                return Ok(info.version);
-            }
-            Err(format!(
-                "Failed to connect to GitHub ({}) and SourceForge fallback failed",
-                e
-            ))
-        }
-    }
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CoreUpdateInfo {
+    provider: String,
+    channel: String,
+    current_version: Option<String>,
+    stable_version: String,
+    status: CoreUpdateStatus,
+    update_available: bool,
+}
+
+#[tauri::command]
+async fn get_core_update_info(
+    use_proxy: Option<bool>,
+    custom_proxy: Option<String>,
+) -> Result<CoreUpdateInfo, String> {
+    let stable = get_remote_core_version(use_proxy, custom_proxy).await?;
+    let provider = core_manager().provider();
+    let current = provider.is_installed().then(|| provider.local_version());
+    let status = current
+        .as_deref()
+        .map_or(CoreUpdateStatus::NotInstalled, |local| {
+            compare_versions(local, &stable)
+        });
+    Ok(CoreUpdateInfo {
+        provider: provider.provider_name().into(),
+        channel: "stable".into(),
+        current_version: current,
+        stable_version: stable,
+        status,
+        update_available: matches!(
+            status,
+            CoreUpdateStatus::NotInstalled | CoreUpdateStatus::UpdateAvailable
+        ),
+    })
 }
 
 fn get_ui_version() -> String {
@@ -1828,204 +1755,66 @@ async fn download_and_install_update(
         .build()
         .map_err(|e| format!("Failed to build http client: {}", e))?;
 
-    // Fetch version from GitHub with fallback to SourceForge
+    // Resolve the managed channel once; the same immutable release metadata is
+    // then used for every mirror attempt in this operation.
     let provider = manager.provider();
-    let mut fetched_from_sf = false;
-    let mut sf_info: Option<CoreRelease> = None;
-
-    let latest_version = match client
-        .get(provider.version_url())
-        .header("Cache-Control", "no-cache")
-        .send()
-        .await
-    {
-        Ok(resp) if resp.status().is_success() => match resp.text().await {
-            Ok(text) => {
-                let trimmed = text.trim().to_string();
-                if !trimmed.is_empty() && !trimmed.contains("Not Found") {
-                    trimmed
-                } else {
-                    fetched_from_sf = true;
-                    let info = fetch_fallback_release_info(&client).await?;
-                    let version = info.version.clone();
-                    sf_info = Some(info);
-                    version
-                }
+    let release = resolve_stable(&client, provider.provider_name(), GITHUB_USER_AGENT).await?;
+    let latest_version = release.version.clone();
+    if provider.is_installed() {
+        match compare_versions(&provider.local_version(), &latest_version) {
+            CoreUpdateStatus::Ahead | CoreUpdateStatus::Unknown => {
+                return Err(
+                    "The installed core cannot be safely updated to this stable release".into(),
+                )
             }
-            Err(_) => {
-                fetched_from_sf = true;
-                let info = fetch_fallback_release_info(&client).await?;
-                let version = info.version.clone();
-                sf_info = Some(info);
-                version
-            }
-        },
-        _ => {
-            fetched_from_sf = true;
-            let info = fetch_fallback_release_info(&client).await?;
-            let version = info.version.clone();
-            sf_info = Some(info);
-            version
+            CoreUpdateStatus::UpToDate => return Ok("Core is already up to date".into()),
+            _ => {}
         }
-    };
-
+    }
     window.emit("download-progress", 10).ok();
-
     let zip_path = temp_dir.join("update.zip");
-
-    use std::sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    };
-    let done_flag = Arc::new(AtomicBool::new(false));
-    let done_flag_thread = done_flag.clone();
-    let window_clone = window.clone();
-    std::thread::spawn(move || {
-        let steps: &[u16] = &[15, 20, 28, 35, 42, 50, 58, 65, 72, 78, 83, 88];
-        for pct in steps {
-            if done_flag_thread.load(Ordering::Relaxed) {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_secs(3));
-            if done_flag_thread.load(Ordering::Relaxed) {
-                break;
-            }
-            window_clone.emit("download-progress", *pct).ok();
-        }
-    });
-
-    // 1. Try downloading from GitHub
-    let mut response = None;
-    let mut downloaded_from_sf = false;
-
-    if !fetched_from_sf {
-        let github_url = provider.release_download_url(&latest_version);
-        if let Ok(resp) = client.get(&github_url).send().await {
-            if resp.status().is_success() {
-                response = Some(resp);
-            }
-        }
-    }
-
-    // 2. If GitHub failed or wasn't tried, try SourceForge
-    if response.is_none() {
-        // Ensure we have SF info loaded
-        let info = match sf_info {
-            Some(i) => i,
-            None => fetch_fallback_release_info(&client).await?,
-        };
-
-        // Try downloading from the direct SourceForge URL
-        match client.get(&info.download_url).send().await {
-            Ok(resp) if resp.status().is_success() => {
-                response = Some(resp);
-                downloaded_from_sf = true;
-                sf_info = Some(info);
-            }
-            _ => {
-                // Also try downloading from the generic latest URL user requested as fallback
-                let generic_url = manager.fallback_latest_url();
-                match client.get(generic_url).send().await {
-                    Ok(resp) if resp.status().is_success() => {
-                        response = Some(resp);
-                        downloaded_from_sf = true;
-                        sf_info = Some(info);
-                    }
-                    Ok(resp) => {
-                        done_flag.store(true, Ordering::Relaxed);
-                        return Err(format!(
-                            "SourceForge download failed with status: {}",
-                            resp.status()
-                        ));
-                    }
-                    Err(e) => {
-                        done_flag.store(true, Ordering::Relaxed);
-                        return Err(format!(
-                            "Failed to download from both GitHub and SourceForge. SF error: {}",
-                            e
-                        ));
-                    }
-                }
-            }
-        }
-    }
-
-    let response = response.unwrap();
-
     use futures_util::StreamExt;
-    let mut file = std::fs::File::create(&zip_path).map_err(|e| {
-        done_flag.store(true, Ordering::Relaxed);
-        format!("Failed to create update zip file: {}", e)
-    })?;
-
-    let mut stream = response.bytes_stream();
-    while let Some(chunk) = stream.next().await {
-        match chunk {
-            Ok(bytes) => {
-                use std::io::Write;
-                if let Err(e) = file.write_all(&bytes) {
-                    done_flag.store(true, Ordering::Relaxed);
-                    return Err(format!("Failed to write to zip file: {}", e));
-                }
-            }
-            Err(e) => {
-                done_flag.store(true, Ordering::Relaxed);
-                return Err(format!("Error while downloading: {}", e));
-            }
-        }
-    }
-
-    done_flag.store(true, Ordering::Relaxed);
-
-    if !zip_path.exists() {
-        return Err("Download failed: output file not found".to_string());
-    }
-
-    // Verify integrity of downloaded archive before extraction.
-    let verified_checksum;
-    let source_url;
-    if downloaded_from_sf {
-        if let Some(info) = sf_info {
-            let expected_md5 = match info.checksum {
-                Some(Checksum::Md5(value)) => value,
-                _ => {
-                    return Err(
-                        "Downloaded from SourceForge but MD5 metadata is missing".to_string()
-                    )
-                }
-            };
-            let actual_md5 = md5_file(&zip_path)?;
-            if actual_md5 != expected_md5.to_ascii_lowercase() {
-                let _ = std::fs::remove_file(&zip_path);
-                return Err(format!(
-                    "Checksum mismatch (MD5) for SourceForge download: expected {}, got {}",
-                    expected_md5, actual_md5
-                ));
-            }
-            verified_checksum = Checksum::Md5(expected_md5);
-            source_url = Some(info.download_url);
-        } else {
-            return Err("Downloaded from SourceForge but release metadata is missing".to_string());
-        }
-    } else {
-        let asset_name = provider.archive_name(&latest_version);
-        let expected_checksum =
-            Checksum::Sha256(fetch_expected_sha256(&latest_version, &asset_name).await?);
-        let expected_sha256 = match expected_checksum {
-            Checksum::Sha256(value) => value,
-            Checksum::Md5(_) => unreachable!("GitHub releases require SHA-256"),
+    let mut selected = None;
+    for artifact in &release.artifacts {
+        let _ = std::fs::remove_file(&zip_path);
+        let response = match client.get(&artifact.url).send().await {
+            Ok(response) if response.status().is_success() => response,
+            _ => continue,
         };
-        let actual_sha256 = sha256_file(&zip_path)?;
-        if actual_sha256 != expected_sha256 {
-            let _ = std::fs::remove_file(&zip_path);
-            return Err(format!(
-                "Checksum mismatch (SHA-256) for {}: expected {}, got {}",
-                asset_name, expected_sha256, actual_sha256
-            ));
+        let mut file = std::fs::File::create(&zip_path)
+            .map_err(|e| format!("Failed to create update archive: {e}"))?;
+        let mut stream = response.bytes_stream();
+        let mut failed = false;
+        while let Some(chunk) = stream.next().await {
+            match chunk {
+                Ok(bytes) => {
+                    use std::io::Write;
+                    if file.write_all(&bytes).is_err() {
+                        failed = true;
+                        break;
+                    }
+                }
+                Err(_) => {
+                    failed = true;
+                    break;
+                }
+            }
         }
-        verified_checksum = Checksum::Sha256(expected_sha256);
-        source_url = Some(provider.release_download_url(&latest_version));
+        drop(file);
+        if failed {
+            continue;
+        }
+        let actual = sha256_file(&zip_path)?;
+        if actual == artifact.checksum.value {
+            selected = Some((artifact.url.clone(), Checksum::Sha256(actual)));
+            break;
+        }
+        let _ = std::fs::remove_file(&zip_path);
+        eprintln!("Core artifact checksum mismatch: {}", artifact.url);
     }
+    let (source_url, verified_checksum) = selected
+        .map(|(url, checksum)| (Some(url), checksum))
+        .ok_or_else(|| "No stable core artifact could be downloaded and verified".to_string())?;
 
     // Extraction
     window.emit("download-progress", 92).ok();
@@ -2076,6 +1865,9 @@ async fn download_and_install_update(
         installation.remove_owned_staging(&staging)?;
         return Err(error);
     }
+    let mut installed_manifest = core::CoreManifest::read(&staging)?;
+    installed_manifest.channel = Some(release.channel.clone());
+    installed_manifest.write_atomic(&staging)?;
     installation.preserve_user_files(&dir, &staging)?;
 
     // Capture the exact runtime state only after the candidate is ready, just
@@ -3743,6 +3535,7 @@ pub fn run() {
             import_backup_file,
             update_ipset_list,
             get_remote_core_version,
+            get_core_update_info,
             download_and_install_update,
             get_core_installation_state,
             rollback_core_update,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2039,11 +2039,11 @@ mod temporary_cleanup_tests {
             let path = temp_parent.join(format!("{prefix}test-{}", std::process::id()));
             let _ = std::fs::remove_dir_all(&path);
             std::fs::create_dir(&path).unwrap();
-            let result: Result<(), &str> = (|| {
+            let result: Result<(), &str> = {
                 let _cleanup =
                     OwnedDirectoryCleanup::new(path.clone(), expected_parent.clone(), prefix);
                 Err("simulated failure")
-            })();
+            };
             assert!(result.is_err());
             assert!(!path.exists());
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -592,7 +592,8 @@ async fn get_core_update_info(
     custom_proxy: Option<String>,
 ) -> Result<CoreUpdateInfo, String> {
     let stable = get_remote_core_version(use_proxy, custom_proxy).await?;
-    let provider = core_manager().provider();
+    let manager = core_manager();
+    let provider = manager.provider();
     let current = provider.is_installed().then(|| provider.local_version());
     let status = current
         .as_deref()
@@ -1805,7 +1806,11 @@ async fn download_and_install_update(
             continue;
         }
         let actual = sha256_file(&zip_path)?;
-        if actual == artifact.checksum.value {
+        let expected = match &artifact.checksum {
+            Checksum::Sha256(value) => value,
+            Checksum::Md5(_) => continue,
+        };
+        if actual == *expected {
             selected = Some((artifact.url.clone(), Checksum::Sha256(actual)));
             break;
         }

--- a/src-tauri/src/providers/flowseal.rs
+++ b/src-tauri/src/providers/flowseal.rs
@@ -1,15 +1,7 @@
 use std::{cmp::Ordering, path::PathBuf};
 
-use crate::core::{Checksum, CorePaths, CoreProvider, CoreRelease};
+use crate::core::{CorePaths, CoreProvider};
 
-const VERSION_URL: &str =
-    "https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/main/.service/version.txt";
-const RELEASE_API: &str =
-    "https://api.github.com/repos/Flowseal/zapret-discord-youtube/releases/tags";
-const FALLBACK_METADATA_URL: &str =
-    "https://sourceforge.net/projects/zapret-discord-youtube.mirror/best_release.json";
-const FALLBACK_LATEST_URL: &str =
-    "https://sourceforge.net/projects/zapret-discord-youtube.mirror/files/latest/download";
 const IPSET_URL: &str = "https://raw.githubusercontent.com/Flowseal/zapret-discord-youtube/refs/heads/main/.service/ipset-service.txt";
 
 pub struct FlowsealProvider {
@@ -36,33 +28,6 @@ impl FlowsealProvider {
             })
             .filter(|version| !version.is_empty())
             .ok_or_else(|| "Err: No Version String Found".to_string())
-    }
-
-    pub async fn fetch_fallback_release(
-        &self,
-        client: &reqwest::Client,
-    ) -> Result<CoreRelease, String> {
-        let response = client
-            .get(FALLBACK_METADATA_URL)
-            .header("Cache-Control", "no-cache")
-            .send()
-            .await
-            .map_err(|e| format!("Failed to send SourceForge request: {e}"))?;
-        if !response.status().is_success() {
-            return Err(format!(
-                "SourceForge returned status: {}",
-                response.status()
-            ));
-        }
-        let body = response
-            .json()
-            .await
-            .map_err(|e| format!("Failed to parse SourceForge JSON: {e}"))?;
-        parse_fallback_release(&body)
-    }
-
-    pub fn fallback_latest_url(&self) -> &'static str {
-        FALLBACK_LATEST_URL
     }
 
     fn parse_strategy_content(
@@ -129,21 +94,6 @@ impl CoreProvider for FlowsealProvider {
     }
     fn paths(&self) -> &CorePaths {
         &self.paths
-    }
-    fn version_url(&self) -> &'static str {
-        VERSION_URL
-    }
-    fn release_api_url(&self, version: &str) -> String {
-        format!("{RELEASE_API}/{version}")
-    }
-    fn archive_name(&self, version: &str) -> String {
-        format!("zapret-discord-youtube-{version}.zip")
-    }
-    fn release_download_url(&self, version: &str) -> String {
-        format!(
-            "https://github.com/Flowseal/zapret-discord-youtube/releases/download/{version}/{}",
-            self.archive_name(version)
-        )
     }
     fn ipset_url(&self) -> &'static str {
         IPSET_URL
@@ -241,36 +191,6 @@ impl CoreProvider for FlowsealProvider {
     }
 }
 
-pub fn parse_fallback_release(body: &serde_json::Value) -> Result<CoreRelease, String> {
-    let release = body
-        .pointer("/platform_releases/windows")
-        .or_else(|| body.get("release"))
-        .ok_or_else(|| "No release information found in SourceForge JSON".to_string())?;
-    let filename = release
-        .get("filename")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| "Missing filename in SourceForge JSON".to_string())?;
-    Ok(CoreRelease {
-        version: filename
-            .split('/')
-            .find(|s| !s.is_empty())
-            .ok_or_else(|| "Failed to parse version from SourceForge filename".to_string())?
-            .to_owned(),
-        download_url: release
-            .get("url")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| "Missing url in SourceForge JSON".to_string())?
-            .to_owned(),
-        checksum: Some(Checksum::Md5(
-            release
-                .get("md5sum")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| "Missing md5sum in SourceForge JSON".to_string())?
-                .to_owned(),
-        )),
-    })
-}
-
 fn natural_compare(a: &str, b: &str) -> Ordering {
     let (mut a, mut b) = (a.chars().peekable(), b.chars().peekable());
     loop {
@@ -306,27 +226,6 @@ mod tests {
         let _ = std::fs::remove_dir_all(&p);
         std::fs::create_dir_all(&p).expect("temp");
         p
-    }
-    #[test]
-    fn release_urls_and_names() {
-        let p = FlowsealProvider::new("x");
-        assert_eq!(p.archive_name("1.2"), "zapret-discord-youtube-1.2.zip");
-        assert!(p
-            .release_download_url("1.2")
-            .ends_with("/1.2/zapret-discord-youtube-1.2.zip"));
-    }
-    #[test]
-    fn parses_sourceforge_release_with_md5() {
-        let body = serde_json::json!({
-            "platform_releases": { "windows": {
-                "filename": "/v1/archive.zip",
-                "url": "https://example.invalid/archive.zip",
-                "md5sum": "abcdef"
-            }}
-        });
-        let release = parse_fallback_release(&body).expect("fallback release");
-        assert_eq!(release.version, "v1");
-        assert_eq!(release.checksum, Some(Checksum::Md5("abcdef".to_string())));
     }
 
     #[test]

--- a/src/features/updates.js
+++ b/src/features/updates.js
@@ -141,6 +141,11 @@ function showDualUpdateModal(data, manual = false) {
     unknown: t('core_update_unknown'),
   };
   const coreStatus = `<span class="${data.core.available ? 'text-secondary' : 'text-on-surface-variant/70'} text-[10px] font-bold uppercase">${coreStatusLabels[data.core.status] || t('core_update_unknown')}</span>`;
+  const coreCurrentVersion = data.core.status === 'not_installed'
+    ? t('core_not_installed')
+    : data.core.status === 'unknown'
+      ? t('core_version_unknown')
+      : `v${data.core.current}`;
 
   modal.innerHTML = `
     <div class="bg-surface-container-high border border-outline-variant/30 rounded-3xl p-8 max-w-lg w-full shadow-2xl animate-scale-in">
@@ -169,7 +174,7 @@ function showDualUpdateModal(data, manual = false) {
             <div class="flex flex-col items-start text-left">
               <span class="text-[10px] font-bold text-secondary/70 uppercase tracking-wider mb-1">${t('zapret_core')} · ${t('core_stable_channel')}</span>
               <div class="flex items-center gap-2">
-                <span class="text-sm font-bold text-on-surface">v${data.core.current}</span>
+                <span class="text-sm font-bold text-on-surface">${coreCurrentVersion}</span>
                 ${data.core.available ? `<span class="material-symbols-outlined text-xs text-on-surface-variant/40">arrow_forward</span> <span class="text-sm font-bold text-secondary">${data.core.latest === 'Error' ? 'Ошибка' : 'v' + data.core.latest}</span>` : ''}
               </div>
             </div>

--- a/src/features/updates.js
+++ b/src/features/updates.js
@@ -133,9 +133,14 @@ function showDualUpdateModal(data, manual = false) {
   const uiStatus = data.ui.available
     ? `<span class="px-2 py-0.5 bg-primary/20 text-primary text-[10px] font-bold rounded-full uppercase">${t('update_available_short')}</span>`
     : `<span class="text-on-surface-variant/50 text-[10px] font-bold uppercase">${t('up_to_date')}</span>`;
-  const coreStatus = data.core.available
-    ? `<span class="px-2 py-0.5 bg-secondary/20 text-secondary text-[10px] font-bold rounded-full uppercase">${t('update_available_short')}</span>`
-    : `<span class="text-on-surface-variant/50 text-[10px] font-bold uppercase">${t('up_to_date')}</span>`;
+  const coreStatusLabels = {
+    update_available: t('update_available_short'),
+    not_installed: t('core_not_installed'),
+    up_to_date: t('up_to_date'),
+    ahead: t('core_update_ahead'),
+    unknown: t('core_update_unknown'),
+  };
+  const coreStatus = `<span class="${data.core.available ? 'text-secondary' : 'text-on-surface-variant/70'} text-[10px] font-bold uppercase">${coreStatusLabels[data.core.status] || t('core_update_unknown')}</span>`;
 
   modal.innerHTML = `
     <div class="bg-surface-container-high border border-outline-variant/30 rounded-3xl p-8 max-w-lg w-full shadow-2xl animate-scale-in">
@@ -170,7 +175,7 @@ function showDualUpdateModal(data, manual = false) {
             </div>
             <div class="flex flex-col items-end gap-3">
               ${coreStatus}
-              ${data.core.available ? `<button id="modal-update-core-btn" class="px-4 py-2 bg-secondary/20 hover:bg-secondary/30 border border-secondary/20 rounded-xl text-[10px] font-black text-secondary uppercase transition-all active:scale-95 shadow-lg shadow-secondary/5">${t('update_now')}</button>` : ''}
+              ${(data.core.status === 'update_available' || data.core.status === 'not_installed') ? `<button id="modal-update-core-btn" class="px-4 py-2 bg-secondary/20 hover:bg-secondary/30 border border-secondary/20 rounded-xl text-[10px] font-black text-secondary uppercase transition-all active:scale-95 shadow-lg shadow-secondary/5">${t('update_now')}</button>` : ''}
             </div>
           </div>
         </div>
@@ -235,7 +240,7 @@ async function checkForUpdates(manual = false) {
     ]);
 
     const hasUIUpdate = !!uiUpdate;
-    const hasCoreUpdate = coreInfo.updateAvailable;
+    const hasCoreUpdate = coreInfo.status === 'update_available' || coreInfo.status === 'not_installed';
     const showCoreError = manual && coreInfo.status === 'unknown';
 
     if (hasUIUpdate || hasCoreUpdate || showCoreError || manual) {

--- a/src/features/updates.js
+++ b/src/features/updates.js
@@ -162,7 +162,7 @@ function showDualUpdateModal(data, manual = false) {
 
           <div class="flex items-center justify-between p-4 bg-white/5 rounded-2xl border border-white/5">
             <div class="flex flex-col items-start text-left">
-              <span class="text-[10px] font-bold text-secondary/70 uppercase tracking-wider mb-1">${t('zapret_core')}</span>
+              <span class="text-[10px] font-bold text-secondary/70 uppercase tracking-wider mb-1">${t('zapret_core')} · ${t('core_stable_channel')}</span>
               <div class="flex items-center gap-2">
                 <span class="text-sm font-bold text-on-surface">v${data.core.current}</span>
                 ${data.core.available ? `<span class="material-symbols-outlined text-xs text-on-surface-variant/40">arrow_forward</span> <span class="text-sm font-bold text-secondary">${data.core.latest === 'Error' ? 'Ошибка' : 'v' + data.core.latest}</span>` : ''}
@@ -223,26 +223,25 @@ async function checkForUpdates(manual = false) {
 
   try {
     const uiLocalVersion = await invoke('get_ui_version_cmd');
-    const [uiUpdate, coreRemoteVersion, coreLocalVersion] = await Promise.all([
+    const [uiUpdate, coreInfo] = await Promise.all([
       checkUIUpdateWithFallback(),
-      invoke('get_remote_core_version', { useProxy: false, customProxy: null }).catch(async (err) => {
+      invoke('get_core_update_info', { useProxy: false, customProxy: null }).catch(async (err) => {
         try {
-          return await invoke('get_remote_core_version', { useProxy: true, customProxy: null });
+          return await invoke('get_core_update_info', { useProxy: true, customProxy: null });
         } catch {
-          return 'Error';
+          return { status: 'unknown', currentVersion: 'Unknown', stableVersion: 'Error', updateAvailable: false };
         }
       }),
-      invoke('get_local_version_cmd').catch((err) => 'Local Err: ' + err),
     ]);
 
     const hasUIUpdate = !!uiUpdate;
-    const hasCoreUpdate = coreRemoteVersion !== 'Unknown' && coreRemoteVersion !== 'Error' && coreLocalVersion !== 'Unknown' && coreRemoteVersion !== coreLocalVersion;
-    const showCoreError = manual && coreRemoteVersion === 'Error';
+    const hasCoreUpdate = coreInfo.updateAvailable;
+    const showCoreError = manual && coreInfo.status === 'unknown';
 
     if (hasUIUpdate || hasCoreUpdate || showCoreError || manual) {
       showDualUpdateModal({
         ui: { available: hasUIUpdate, current: uiLocalVersion, latest: hasUIUpdate ? uiUpdate.version : uiLocalVersion, updateObj: uiUpdate },
-        core: { available: hasCoreUpdate || showCoreError, current: coreLocalVersion, latest: coreRemoteVersion },
+        core: { available: hasCoreUpdate, current: coreInfo.currentVersion || t('not_installed'), latest: coreInfo.stableVersion, status: coreInfo.status, error: showCoreError },
       }, manual);
     }
   } catch (err) {

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -3,6 +3,7 @@ export default {
     "core_update_unknown": "Core versions cannot be compared safely. Automatic update is unavailable.",
     "core_update_ahead": "Installed core is newer than Stable. No downgrade will be offered.",
     "core_not_installed": "Core is not installed",
+    "core_version_unknown": "Core version is unknown",
     "core_rollback_title": "Core rollback",
     "core_current_version": "Current version",
     "core_previous_version": "Previous version",

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -1,4 +1,6 @@
 export default {
+    "core_stable_channel": "Flowseal · Stable",
+    "core_update_unknown": "Core versions cannot be compared safely. Automatic update is unavailable.",
     "core_rollback_title": "Core rollback",
     "core_current_version": "Current version",
     "core_previous_version": "Previous version",

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -1,6 +1,8 @@
 export default {
     "core_stable_channel": "Flowseal · Stable",
     "core_update_unknown": "Core versions cannot be compared safely. Automatic update is unavailable.",
+    "core_update_ahead": "Installed core is newer than Stable. No downgrade will be offered.",
+    "core_not_installed": "Core is not installed",
     "core_rollback_title": "Core rollback",
     "core_current_version": "Current version",
     "core_previous_version": "Previous version",

--- a/src/i18n/ru.js
+++ b/src/i18n/ru.js
@@ -1,6 +1,8 @@
 export default {
     "core_stable_channel": "Flowseal · Stable",
     "core_update_unknown": "Версии ядра нельзя безопасно сравнить. Автоматическое обновление недоступно.",
+    "core_update_ahead": "Установленное ядро новее Stable. Понижение версии не предлагается.",
+    "core_not_installed": "Ядро не установлено",
     "core_rollback_title": "Откат ядра",
     "core_current_version": "Текущая версия",
     "core_previous_version": "Предыдущая версия",

--- a/src/i18n/ru.js
+++ b/src/i18n/ru.js
@@ -1,4 +1,6 @@
 export default {
+    "core_stable_channel": "Flowseal · Stable",
+    "core_update_unknown": "Версии ядра нельзя безопасно сравнить. Автоматическое обновление недоступно.",
     "core_rollback_title": "Откат ядра",
     "core_current_version": "Текущая версия",
     "core_previous_version": "Предыдущая версия",

--- a/src/i18n/ru.js
+++ b/src/i18n/ru.js
@@ -3,6 +3,7 @@ export default {
     "core_update_unknown": "Версии ядра нельзя безопасно сравнить. Автоматическое обновление недоступно.",
     "core_update_ahead": "Установленное ядро новее Stable. Понижение версии не предлагается.",
     "core_not_installed": "Ядро не установлено",
+    "core_version_unknown": "Версия ядра неизвестна",
     "core_rollback_title": "Откат ядра",
     "core_current_version": "Текущая версия",
     "core_previous_version": "Предыдущая версия",


### PR DESCRIPTION
### Motivation

- Prevent automatic adoption of upstream Flowseal "latest" by making the stable core release explicit and controllable via a small repository manifest. 
- Provide a provider-neutral manifest resolver and installer path so the app verifies and selects the exact artifact(s) to download and install. 
- Ensure first-install, atomic activation, post-activation validation and rollback semantics are safe and idempotent. 
- Give maintainers a scripted, auditable promotion flow that computes exact SHA-256 checksums for published stable artifacts.

### Description

- Added a provider-neutral managed stable-channel resolver and strict manifest model in `src-tauri/src/core/channel.rs` that enforces `schemaVersion=1`, `channel="stable"`, provider match, HTTPS-only artifacts and lowercase 64-hex SHA-256 checks, with a 256 KiB limit and an embedded fallback manifest. 
- Switched core resolution and installation to use a single resolved manifest (`resolve_stable`) and to iterate artifacts sequentially: stream download to a temp file, verify SHA-256 before extraction, and refuse implicit downgrades or unsafe updates. 
- Extended `CoreManifest` with a backward-compatible optional `channel` field and persist channel provenance into the installation manifest; updated the transactional install/activation flow to support safe first-install (no `binaries.previous` created) with mandatory post-activation validation and cleanup on failure. 
- Added `get_core_update_info` provider-neutral command and `compare_versions` semantics (`not_installed`, `update_available`, `up_to_date`, `ahead`, `unknown`), and updated the frontend to use this info so `ahead`/`unknown` states do not offer automatic downgrade. 
- Added maintainer tooling and docs: `scripts/promote-core-stable.mjs` to download artifacts, compute SHA-256, and atomically write `core-channel/stable.json`, and `docs/core-release-channel.md` documenting the promotion workflow. 
- UI strings updated to label the channel as `Flowseal · Stable` and to display friendly messages for unknown/comparison-failure cases. 
- Created a placeholder embedded manifest at `core-channel/stable.json` intentionally empty because the execution environment could not verify upstream artifacts; maintainers must run the promotion script in a networked environment to populate real version and checksums. 

### Testing

- Ran `git diff --check` which passed and `node --check scripts/promote-core-stable.mjs` which validated the promotion script syntax. 
- Ran `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` which passed for the Rust changes. 
- Attempted `npm ci` / `npm run build` which was blocked on Linux due to an explicit Windows-only binary dependency (`@tailwindcss/oxide-win32-x64-msvc`) causing `EBADPLATFORM`, so frontend build verification could not complete. 
- Attempted `cargo test` and `cargo clippy` but they were blocked by missing system native dependencies for Tauri (system `glib-2.0` / pkg-config) in the CI image so Rust unit tests could not be fully executed here; several new unit tests were added under `src-tauri/src/core/installation.rs` and `src-tauri/src/core/channel.rs` and should be run in a networked, platform-complete environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66289738b08330b2957f56f8c2f6e4)