### PR TITLE
ci: automate Flowseal stable release checks

### DIFF
--- a/.github/workflows/check-flowseal-release.yml
+++ b/.github/workflows/check-flowseal-release.yml
@@ -16,27 +16,19 @@ jobs:
   check-release:
     name: Check and propose stable core update
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.FLOWSEAL_UPDATE_TOKEN }}
     steps:
-      - name: Check update token
-        run: |
-          if [ -z "$GH_TOKEN" ]; then
-            echo "::error::The FLOWSEAL_UPDATE_TOKEN repository secret is required."
-            exit 1
-          fi
-
-      - name: Check out main with update token
-        uses: actions/checkout@v4
+      - name: Check out main without persisted credentials
+        uses: actions/checkout@v7
         with:
           ref: main
-          token: ${{ secrets.FLOWSEAL_UPDATE_TOKEN }}
+          token: ${{ github.token }}
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 20
           cache: npm
 
       - name: Read latest published Flowseal release
@@ -51,10 +43,8 @@ jobs:
             --output "$response" --write-out '%{http_code}' "$API_URL")"
           if [ "$status" != 200 ]; then
             echo "::error::GitHub releases/latest returned HTTP $status."
-            cat "$response"
             exit 1
           fi
-
           if [ "$(jq -r '.draft // false' "$response")" != false ] || \
              [ "$(jq -r '.prerelease // false' "$response")" != false ]; then
             echo "::error::GitHub releases/latest unexpectedly returned a draft or prerelease."
@@ -62,104 +52,124 @@ jobs:
           fi
 
           tag="$(jq -er '.tag_name | select(type == "string" and length > 0)' "$response")"
-          version="${tag#v}"
-          if [ -z "$version" ]; then
-            echo "::error::The latest release tag produces an empty version."
-            exit 1
-          fi
+          current_version="$(jq -er '.version' core-channel/stable.json)"
+          node scripts/flowseal-version.mjs "$tag" "$current_version" >> "$GITHUB_OUTPUT"
+          version="$(node -e "import('./scripts/flowseal-version.mjs').then(({normalizeVersion}) => process.stdout.write(normalizeVersion(process.argv[1]) ?? ''))" "$tag")"
           expected="zapret-discord-youtube-${version}.zip"
           asset_count="$(jq --arg expected "$expected" '[.assets[]? | select(.name == $expected and (.browser_download_url | type == "string"))] | length' "$response")"
           if [ "$asset_count" != 1 ]; then
             echo "::error::Expected exactly one release asset named $expected, found $asset_count."
             exit 1
           fi
-
-          asset_url="$(jq -er --arg expected "$expected" '.assets[] | select(.name == $expected) | .browser_download_url' "$response")"
-          release_url="$(jq -er '.html_url' "$response")"
-          current_version="$(jq -er '.version' core-channel/stable.json)"
           {
-            echo "version=$version"
-            echo "asset_url=$asset_url"
-            echo "release_url=$release_url"
+            echo "asset_url=$(jq -er --arg expected "$expected" '.assets[] | select(.name == $expected) | .browser_download_url' "$response")"
+            echo "release_url=$(jq -er '.html_url' "$response")"
             echo "current_version=$current_version"
           } >> "$GITHUB_OUTPUT"
-          echo "Latest published stable Flowseal release: $version (current: $current_version)."
 
-      - name: Stop when stable is current
-        id: current
+      - name: Decide whether promotion is needed
+        id: decision
         env:
+          COMPARISON: ${{ steps.release.outputs.comparison }}
           CURRENT_VERSION: ${{ steps.release.outputs.current_version }}
           LATEST_VERSION: ${{ steps.release.outputs.version }}
         run: |
-          if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
-            echo "Flowseal $LATEST_VERSION is already the managed stable version; no branch or PR is needed."
-            echo "matches=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Flowseal $LATEST_VERSION is newer than managed stable $CURRENT_VERSION."
-            echo "matches=false" >> "$GITHUB_OUTPUT"
-          fi
+          case "$COMPARISON" in
+            equal)
+              echo "Flowseal $LATEST_VERSION is already stable; no branch or PR is needed."
+              echo "promote=false" >> "$GITHUB_OUTPUT"
+              ;;
+            older)
+              echo "::warning::Managed stable $CURRENT_VERSION is newer than latest Flowseal release $LATEST_VERSION; refusing to downgrade."
+              echo "promote=false" >> "$GITHUB_OUTPUT"
+              ;;
+            newer) echo "promote=true" >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error::Unknown version comparison result: $COMPARISON"; exit 1 ;;
+          esac
 
-      - name: Prepare safe branch name
-        if: steps.current.outputs.matches == 'false'
+      - name: Prepare safe automation branch
+        if: steps.decision.outputs.promote == 'true'
         id: branch
         env:
           VERSION: ${{ steps.release.outputs.version }}
         run: |
-          safe_version="$(printf '%s' "$VERSION" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g; s/^[.-]+//; s/[.-]+$//; s/-+/-/g' | cut -c1-100)"
-          if [ -z "$safe_version" ]; then
-            echo "::error::Version '$VERSION' cannot be safely normalized for a branch name."
-            exit 1
-          fi
+          safe_version="$(printf '%s' "$VERSION" | sed -E 's/[^0-9.]+/-/g; s/^[.-]+//; s/[.-]+$//' | cut -c1-100)"
           branch="automation/flowseal-$safe_version"
           git check-ref-format --branch "$branch" >/dev/null
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
-          echo "Automation branch: $branch"
 
-      - name: Check for an existing branch or pull request
-        if: steps.current.outputs.matches == 'false'
-        id: duplicate
+      - name: Check for an existing pull request
+        if: steps.decision.outputs.promote == 'true'
+        id: pull_request
         env:
+          GH_TOKEN: ${{ secrets.FLOWSEAL_UPDATE_TOKEN }}
           BRANCH: ${{ steps.branch.outputs.branch }}
         run: |
-          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            echo "Branch $BRANCH already exists; no duplicate branch or PR will be created."
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          pr_count="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "$BRANCH" --json number --jq 'length')"
-          if [ "$pr_count" -gt 0 ]; then
-            echo "An open PR for $BRANCH already exists; no duplicate PR will be created."
+          if [ -z "$GH_TOKEN" ]; then echo "::error::FLOWSEAL_UPDATE_TOKEN is required."; exit 1; fi
+          pr_url="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "$BRANCH" --json url --jq '.[0].url // empty')"
+          if [ -n "$pr_url" ]; then
+            echo "An open PR already exists: $pr_url"
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Inspect an existing automation branch
+        if: steps.decision.outputs.promote == 'true' && steps.pull_request.outputs.exists == 'false'
+        id: existing_branch
+        env:
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          VERSION: ${{ steps.release.outputs.version }}
+          ASSET_URL: ${{ steps.release.outputs.asset_url }}
+        run: |
+          if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --no-tags origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+          remote_ref="refs/remotes/origin/$BRANCH"
+          changed="$(git diff --name-only main..."$remote_ref")"
+          manifest="$(mktemp)"
+          git show "$remote_ref:core-channel/stable.json" > "$manifest"
+          if [ "$changed" != "core-channel/stable.json" ] || \
+             [ "$(jq -r '.version' "$manifest")" != "$VERSION" ] || \
+             [ "$(jq -r '.artifacts | length' "$manifest")" != 1 ] || \
+             [ "$(jq -r '.artifacts[0].url' "$manifest")" != "$ASSET_URL" ] || \
+             ! jq -e '.artifacts[0].checksum | .algorithm == "sha256" and (.value | test("^[0-9a-f]{64}$"))' "$manifest" >/dev/null; then
+            echo "::error::Branch $BRANCH exists without an open PR but does not contain only the expected verified stable manifest. Inspect, fix, or delete that branch before rerunning."
+            exit 1
+          fi
+          echo "Validated existing branch $BRANCH; the workflow will recover by creating its missing PR."
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+          echo "checksum=$(jq -r '.artifacts[0].checksum.value' "$manifest")" >> "$GITHUB_OUTPUT"
+
       - name: Promote Flowseal release in managed channel
-        if: steps.current.outputs.matches == 'false' && steps.duplicate.outputs.exists == 'false'
+        if: steps.decision.outputs.promote == 'true' && steps.pull_request.outputs.exists == 'false' && steps.existing_branch.outputs.exists == 'false'
         env:
           VERSION: ${{ steps.release.outputs.version }}
           ASSET_URL: ${{ steps.release.outputs.asset_url }}
         run: npm run promote-core-stable -- --version "$VERSION" --url "$ASSET_URL"
 
       - name: Verify the promotion diff
-        if: steps.current.outputs.matches == 'false' && steps.duplicate.outputs.exists == 'false'
+        if: steps.decision.outputs.promote == 'true' && steps.pull_request.outputs.exists == 'false' && steps.existing_branch.outputs.exists == 'false'
         id: manifest
         run: |
-          changed="$(git status --porcelain | sed -E 's/^...//' )"
+          changed="$(git status --porcelain | sed -E 's/^...//')"
           if [ "$changed" != "core-channel/stable.json" ]; then
             echo "::error::Promotion must change only core-channel/stable.json; changed paths: ${changed:-none}"
             exit 1
           fi
           git diff --check
-          checksum="$(jq -er '.artifacts[0].checksum | select(.algorithm == "sha256") | .value | select(test("^[0-9a-f]{64}$"))' core-channel/stable.json)"
-          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+          echo "checksum=$(jq -er '.artifacts[0].checksum | select(.algorithm == "sha256") | .value | select(test("^[0-9a-f]{64}$"))' core-channel/stable.json)" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push automation branch
-        if: steps.current.outputs.matches == 'false' && steps.duplicate.outputs.exists == 'false'
+        if: steps.decision.outputs.promote == 'true' && steps.pull_request.outputs.exists == 'false' && steps.existing_branch.outputs.exists == 'false'
         env:
+          GH_TOKEN: ${{ secrets.FLOWSEAL_UPDATE_TOKEN }}
           BRANCH: ${{ steps.branch.outputs.branch }}
           VERSION: ${{ steps.release.outputs.version }}
         run: |
+          gh auth setup-git
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git switch -c "$BRANCH"
@@ -168,14 +178,15 @@ jobs:
           git push --set-upstream origin "$BRANCH"
 
       - name: Create pull request for manual testing
-        if: steps.current.outputs.matches == 'false' && steps.duplicate.outputs.exists == 'false'
+        if: steps.decision.outputs.promote == 'true' && steps.pull_request.outputs.exists == 'false'
         env:
+          GH_TOKEN: ${{ secrets.FLOWSEAL_UPDATE_TOKEN }}
           BRANCH: ${{ steps.branch.outputs.branch }}
           VERSION: ${{ steps.release.outputs.version }}
           CURRENT_VERSION: ${{ steps.release.outputs.current_version }}
           RELEASE_URL: ${{ steps.release.outputs.release_url }}
           ASSET_URL: ${{ steps.release.outputs.asset_url }}
-          CHECKSUM: ${{ steps.manifest.outputs.checksum }}
+          CHECKSUM: ${{ steps.existing_branch.outputs.checksum || steps.manifest.outputs.checksum }}
         run: |
           body="$(mktemp)"
           cat > "$body" <<EOF
@@ -200,9 +211,8 @@ jobs:
           - [ ] После отката восстанавливается выбранная стратегия
           - [ ] Приложение нормально запускается после перезагрузки
           EOF
-          pr_url="$(gh pr create --repo "$GITHUB_REPOSITORY" --base main --head "$BRANCH" \
-            --title "chore(core): promote Flowseal $VERSION to stable" --body-file "$body")"
+          pr_url="$(gh pr create --repo "$GITHUB_REPOSITORY" --base main --head "$BRANCH" --title "chore(core): promote Flowseal $VERSION to stable" --body-file "$body")"
           echo "Created pull request: $pr_url"
           if ! gh pr edit "$pr_url" --add-assignee larrriiin; then
-            echo "::warning::Pull request was created, but GitHub did not allow assigning larrriiin."
+            echo "::warning::PR was created, but GitHub did not allow assigning larrriiin."
           fi

--- a/.github/workflows/check-flowseal-release.yml
+++ b/.github/workflows/check-flowseal-release.yml
@@ -31,15 +31,20 @@ jobs:
           node-version: 20
           cache: npm
 
+      - name: Test Flowseal version comparison
+        run: npm run test:flowseal-version
+
       - name: Read latest published Flowseal release
         id: release
         env:
           API_URL: https://api.github.com/repos/Flowseal/zapret-discord-youtube/releases/latest
+          API_TOKEN: ${{ github.token }}
         run: |
           response="$(mktemp)"
           status="$(curl --silent --show-error --location \
             --header 'Accept: application/vnd.github+json' \
             --header 'X-GitHub-Api-Version: 2022-11-28' \
+            --header "Authorization: Bearer $API_TOKEN" \
             --output "$response" --write-out '%{http_code}' "$API_URL")"
           if [ "$status" != 200 ]; then
             echo "::error::GitHub releases/latest returned HTTP $status."

--- a/.github/workflows/check-flowseal-release.yml
+++ b/.github/workflows/check-flowseal-release.yml
@@ -1,0 +1,208 @@
+name: Check Flowseal stable release
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: flowseal-stable-check
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  check-release:
+    name: Check and propose stable core update
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.FLOWSEAL_UPDATE_TOKEN }}
+    steps:
+      - name: Check update token
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::The FLOWSEAL_UPDATE_TOKEN repository secret is required."
+            exit 1
+          fi
+
+      - name: Check out main with update token
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.FLOWSEAL_UPDATE_TOKEN }}
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Read latest published Flowseal release
+        id: release
+        env:
+          API_URL: https://api.github.com/repos/Flowseal/zapret-discord-youtube/releases/latest
+        run: |
+          response="$(mktemp)"
+          status="$(curl --silent --show-error --location \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            --output "$response" --write-out '%{http_code}' "$API_URL")"
+          if [ "$status" != 200 ]; then
+            echo "::error::GitHub releases/latest returned HTTP $status."
+            cat "$response"
+            exit 1
+          fi
+
+          if [ "$(jq -r '.draft // false' "$response")" != false ] || \
+             [ "$(jq -r '.prerelease // false' "$response")" != false ]; then
+            echo "::error::GitHub releases/latest unexpectedly returned a draft or prerelease."
+            exit 1
+          fi
+
+          tag="$(jq -er '.tag_name | select(type == "string" and length > 0)' "$response")"
+          version="${tag#v}"
+          if [ -z "$version" ]; then
+            echo "::error::The latest release tag produces an empty version."
+            exit 1
+          fi
+          expected="zapret-discord-youtube-${version}.zip"
+          asset_count="$(jq --arg expected "$expected" '[.assets[]? | select(.name == $expected and (.browser_download_url | type == "string"))] | length' "$response")"
+          if [ "$asset_count" != 1 ]; then
+            echo "::error::Expected exactly one release asset named $expected, found $asset_count."
+            exit 1
+          fi
+
+          asset_url="$(jq -er --arg expected "$expected" '.assets[] | select(.name == $expected) | .browser_download_url' "$response")"
+          release_url="$(jq -er '.html_url' "$response")"
+          current_version="$(jq -er '.version' core-channel/stable.json)"
+          {
+            echo "version=$version"
+            echo "asset_url=$asset_url"
+            echo "release_url=$release_url"
+            echo "current_version=$current_version"
+          } >> "$GITHUB_OUTPUT"
+          echo "Latest published stable Flowseal release: $version (current: $current_version)."
+
+      - name: Stop when stable is current
+        id: current
+        env:
+          CURRENT_VERSION: ${{ steps.release.outputs.current_version }}
+          LATEST_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
+            echo "Flowseal $LATEST_VERSION is already the managed stable version; no branch or PR is needed."
+            echo "matches=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Flowseal $LATEST_VERSION is newer than managed stable $CURRENT_VERSION."
+            echo "matches=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Prepare safe branch name
+        if: steps.current.outputs.matches == 'false'
+        id: branch
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          safe_version="$(printf '%s' "$VERSION" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g; s/^[.-]+//; s/[.-]+$//; s/-+/-/g' | cut -c1-100)"
+          if [ -z "$safe_version" ]; then
+            echo "::error::Version '$VERSION' cannot be safely normalized for a branch name."
+            exit 1
+          fi
+          branch="automation/flowseal-$safe_version"
+          git check-ref-format --branch "$branch" >/dev/null
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "Automation branch: $branch"
+
+      - name: Check for an existing branch or pull request
+        if: steps.current.outputs.matches == 'false'
+        id: duplicate
+        env:
+          BRANCH: ${{ steps.branch.outputs.branch }}
+        run: |
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Branch $BRANCH already exists; no duplicate branch or PR will be created."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          pr_count="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "$BRANCH" --json number --jq 'length')"
+          if [ "$pr_count" -gt 0 ]; then
+            echo "An open PR for $BRANCH already exists; no duplicate PR will be created."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Promote Flowseal release in managed channel
+        if: steps.current.outputs.matches == 'false' && steps.duplicate.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          ASSET_URL: ${{ steps.release.outputs.asset_url }}
+        run: npm run promote-core-stable -- --version "$VERSION" --url "$ASSET_URL"
+
+      - name: Verify the promotion diff
+        if: steps.current.outputs.matches == 'false' && steps.duplicate.outputs.exists == 'false'
+        id: manifest
+        run: |
+          changed="$(git status --porcelain | sed -E 's/^...//' )"
+          if [ "$changed" != "core-channel/stable.json" ]; then
+            echo "::error::Promotion must change only core-channel/stable.json; changed paths: ${changed:-none}"
+            exit 1
+          fi
+          git diff --check
+          checksum="$(jq -er '.artifacts[0].checksum | select(.algorithm == "sha256") | .value | select(test("^[0-9a-f]{64}$"))' core-channel/stable.json)"
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push automation branch
+        if: steps.current.outputs.matches == 'false' && steps.duplicate.outputs.exists == 'false'
+        env:
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git switch -c "$BRANCH"
+          git add core-channel/stable.json
+          git commit -m "chore(core): promote Flowseal $VERSION to stable"
+          git push --set-upstream origin "$BRANCH"
+
+      - name: Create pull request for manual testing
+        if: steps.current.outputs.matches == 'false' && steps.duplicate.outputs.exists == 'false'
+        env:
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          VERSION: ${{ steps.release.outputs.version }}
+          CURRENT_VERSION: ${{ steps.release.outputs.current_version }}
+          RELEASE_URL: ${{ steps.release.outputs.release_url }}
+          ASSET_URL: ${{ steps.release.outputs.asset_url }}
+          CHECKSUM: ${{ steps.manifest.outputs.checksum }}
+        run: |
+          body="$(mktemp)"
+          cat > "$body" <<EOF
+          ## Flowseal stable core promotion
+
+          - Current stable version: \`$CURRENT_VERSION\`
+          - Proposed version: \`$VERSION\`
+          - [Upstream Flowseal release]($RELEASE_URL)
+          - [Release ZIP]($ASSET_URL)
+          - SHA-256: \`$CHECKSUM\`
+
+          > **Do not merge this PR without completing manual testing.** This automation only proposes a managed-channel update; it does not approve or merge it.
+
+          ## Manual test checklist
+
+          - [ ] Ядро скачивается и устанавливается
+          - [ ] Временный режим запуска работает
+          - [ ] Режим службы Windows работает
+          - [ ] Выбранная стратегия сохраняется после обновления
+          - [ ] Пользовательские списки сохраняются
+          - [ ] Откат на предыдущую версию работает
+          - [ ] После отката восстанавливается выбранная стратегия
+          - [ ] Приложение нормально запускается после перезагрузки
+          EOF
+          pr_url="$(gh pr create --repo "$GITHUB_REPOSITORY" --base main --head "$BRANCH" \
+            --title "chore(core): promote Flowseal $VERSION to stable" --body-file "$body")"
+          echo "Created pull request: $pr_url"
+          if ! gh pr edit "$pr_url" --add-assignee larrriiin; then
+            echo "::warning::Pull request was created, but GitHub did not allow assigning larrriiin."
+          fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,3 +17,5 @@ jobs:
           node-version: 20
       - name: Verify version strings are in sync
         run: node scripts/check-versions.mjs
+      - name: Test Flowseal version comparison
+        run: npm run test:flowseal-version

--- a/docs/core-release-channel.md
+++ b/docs/core-release-channel.md
@@ -12,3 +12,11 @@ Core updates are controlled by `core-channel/stable.json`; the application never
 6. Once merged to `main`, clients receive the approved version without a new application release. Builds retain that manifest as their last-known-good offline fallback.
 
 The initial placeholder manifest intentionally contains no release. The execution environment used to add the channel could not reach GitHub, so no unverifiable production version or checksum was invented. A maintainer must run the promotion command in a networked environment before releasing this build.
+
+## Automated Flowseal release check
+
+The `Check Flowseal stable release` workflow checks the latest published, non-prerelease GitHub Release from `Flowseal/zapret-discord-youtube` every day at 06:17 UTC. It selects the release asset whose name exactly matches the normalized release version, then uses the same promotion script to download it and calculate its SHA-256. If the managed channel already contains that version, the workflow exits without creating a branch or pull request.
+
+Maintainers can also run the check on demand from **Actions → Check Flowseal stable release → Run workflow**. The repository secret `FLOWSEAL_UPDATE_TOKEN` must contain a token that can push a branch and open a pull request; using that token ensures the resulting `pull_request` event runs the repository's normal checks.
+
+For a new version, the automation changes only `core-channel/stable.json` and opens a pull request against `main`. It never merges the pull request, publishes ZAPRET UI, or creates a tag. A human must test the Windows installation, launch modes, strategy and user-list persistence, rollback, and restart behavior before merging the pull request.

--- a/docs/core-release-channel.md
+++ b/docs/core-release-channel.md
@@ -11,12 +11,12 @@ Core updates are controlled by `core-channel/stable.json`; the application never
 5. Open a separate pull request containing the manifest promotion. The script deliberately does not commit, push, merge, or publish.
 6. Once merged to `main`, clients receive the approved version without a new application release. Builds retain that manifest as their last-known-good offline fallback.
 
-The initial placeholder manifest intentionally contains no release. The execution environment used to add the channel could not reach GitHub, so no unverifiable production version or checksum was invented. A maintainer must run the promotion command in a networked environment before releasing this build.
+The stable channel is active. Its current Flowseal version, download URL, and verified checksum are recorded in `core-channel/stable.json`.
 
 ## Automated Flowseal release check
 
 The `Check Flowseal stable release` workflow checks the latest published, non-prerelease GitHub Release from `Flowseal/zapret-discord-youtube` every day at 06:17 UTC. It selects the release asset whose name exactly matches the normalized release version, then uses the same promotion script to download it and calculate its SHA-256. If the managed channel already contains that version, the workflow exits without creating a branch or pull request.
 
-Maintainers can also run the check on demand from **Actions → Check Flowseal stable release → Run workflow**. The repository secret `FLOWSEAL_UPDATE_TOKEN` must contain a token that can push a branch and open a pull request; using that token ensures the resulting `pull_request` event runs the repository's normal checks.
+Maintainers can also run the check on demand from **Actions → Check Flowseal stable release → Run workflow**. The repository secret `FLOWSEAL_UPDATE_TOKEN` must contain a token that can push a branch and open a pull request; using that token ensures the resulting `pull_request` event runs the repository's normal checks. Maintainers should rotate or renew this token periodically before it expires.
 
 For a new version, the automation changes only `core-channel/stable.json` and opens a pull request against `main`. It never merges the pull request, publishes ZAPRET UI, or creates a tag. A human must test the Windows installation, launch modes, strategy and user-list persistence, rollback, and restart behavior before merging the pull request.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "check-versions": "node scripts/check-versions.mjs",
+    "test:flowseal-version": "node --test scripts/flowseal-version.test.mjs",
     "set-version": "node scripts/set-version.mjs",
     "promote-core-stable": "node scripts/promote-core-stable.mjs"
   },

--- a/scripts/flowseal-version.mjs
+++ b/scripts/flowseal-version.mjs
@@ -1,0 +1,42 @@
+import { pathToFileURL } from 'node:url';
+
+const STANDARD_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+export function normalizeVersion(tag) {
+  if (typeof tag !== 'string') return null;
+  const version = tag.startsWith('v') ? tag.slice(1) : tag;
+  return STANDARD_VERSION.test(version) ? version : null;
+}
+
+export function compareVersions(left, right) {
+  const normalizedLeft = normalizeVersion(left);
+  const normalizedRight = normalizeVersion(right);
+  if (!normalizedLeft || !normalizedRight) return null;
+
+  const leftParts = normalizedLeft.split('.').map(BigInt);
+  const rightParts = normalizedRight.split('.').map(BigInt);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] > rightParts[index]) return 1;
+    if (leftParts[index] < rightParts[index]) return -1;
+  }
+  return 0;
+}
+
+function comparisonName(comparison) {
+  if (comparison === 1) return 'newer';
+  if (comparison === -1) return 'older';
+  return 'equal';
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const [latestTag, currentVersion] = process.argv.slice(2);
+  const latestVersion = normalizeVersion(latestTag);
+  const comparison = compareVersions(latestTag, currentVersion);
+  if (!latestVersion || comparison === null) {
+    console.error(`Cannot safely compare Flowseal versions: latest=${JSON.stringify(latestTag)}, current=${JSON.stringify(currentVersion)}. Only canonical numeric x.y.z versions are automated.`);
+    process.exitCode = 1;
+  } else {
+    console.log(`version=${latestVersion}`);
+    console.log(`comparison=${comparisonName(comparison)}`);
+  }
+}

--- a/scripts/flowseal-version.test.mjs
+++ b/scripts/flowseal-version.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { compareVersions, normalizeVersion } from './flowseal-version.mjs';
+
+test('compares a patch update as newer', () => {
+  assert.equal(compareVersions('1.10.1', '1.10.0'), 1);
+});
+
+test('compares identical versions as equal', () => {
+  assert.equal(compareVersions('1.10.0', '1.10.0'), 0);
+});
+
+test('compares numeric components instead of strings', () => {
+  assert.equal(compareVersions('1.9.9', '1.10.0'), -1);
+});
+
+test('removes one leading v', () => {
+  assert.equal(normalizeVersion('v1.10.1'), '1.10.1');
+});
+
+test('returns unknown for a nonstandard version', () => {
+  assert.equal(normalizeVersion('1.10.1-beta.1'), null);
+  assert.equal(compareVersions('not-a-version', '1.10.0'), null);
+});


### PR DESCRIPTION
### Motivation

- Automate the daily detection of new stable Flowseal releases and reduce manual manifest promotion steps.
- Ensure promotions are produced by the existing checksum-generating promotion script and always reviewed by a human before merge.
- Prevent accidental or partial updates by validating the exact ZIP asset, checksum, and that only `core-channel/stable.json` is changed.

### Description

- Add a new GitHub Actions workflow at `.github/workflows/check-flowseal-release.yml` that runs daily at `06:17 UTC` and supports `workflow_dispatch`, uses `concurrency` and minimal `contents: read` permissions, and relies on the `FLOWSEAL_UPDATE_TOKEN` secret for push/PR actions.
- The workflow calls the official REST endpoint `GET /repos/Flowseal/zapret-discord-youtube/releases/latest`, rejects `draft` and `prerelease` releases, normalizes the `tag_name` by removing only a leading `v`, and requires an asset named exactly `zapret-discord-youtube-<VERSION>.zip` (failing with a clear error if absent).
- When a new version is detected the job runs the existing `npm run promote-core-stable -- --version <VERSION> --url <ZIP_URL>` to download artifacts and compute SHA-256, verifies that the promotion changes only `core-channel/stable.json`, generates a safe branch name `automation/flowseal-<SAFE_VERSION>`, prevents duplicate branches/PRs, pushes with `FLOWSEAL_UPDATE_TOKEN`, and opens a PR via `gh` containing current/proposed versions, release links, SHA-256, a manual-testing warning and the required checklist, and attempts to assign `larrriiin` when permitted.
- Update `docs/core-release-channel.md` to document the automated daily check, manual dispatch, required `FLOWSEAL_UPDATE_TOKEN`, the fact that automation only proposes a PR (does not merge/publish/tag), and that a human must complete the testing checklist before merging.

### Testing

- `npm ci`, `npm run build`, and `npm run check-versions` all ran successfully against the local repository state.
- `node --check scripts/promote-core-stable.mjs` succeeded and `git diff --check` returned no issues locally.
- Workflow YAML was validated by parsing with Ruby/Psych for the `schedule` and `workflow_dispatch` triggers (the `actionlint` tool was not available in the environment).
- Network fetch to `origin` failed with an HTTP 403 in this execution environment, so remote push/PR creation and a live run against GitHub could not be exercised here; all other automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66fc37983483309b8f48a069a12e76)