### PR TITLE
chore(core): promote Flowseal 1.10.1 to stable

### DIFF
--- a/core-channel/stable.json
+++ b/core-channel/stable.json
@@ -2,13 +2,13 @@
   "schemaVersion": 1,
   "channel": "stable",
   "provider": "flowseal",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "artifacts": [
     {
-      "url": "https://github.com/Flowseal/zapret-discord-youtube/releases/download/1.10.0/zapret-discord-youtube-1.10.0.zip",
+      "url": "https://github.com/Flowseal/zapret-discord-youtube/releases/download/1.10.1/zapret-discord-youtube-1.10.1.zip",
       "checksum": {
         "algorithm": "sha256",
-        "value": "6b7c5a66cfd055b8e361f8b5fb00f00b167260f21b1c03d589f6008417fb94a2"
+        "value": "f748d61fec75e4edc992cb5b09d554e914197c68c690384aceb61f143d8f76c9"
       }
     }
   ]


### PR DESCRIPTION
## Flowseal stable core promotion

- Current stable version: `1.10.0`
- Proposed version: `1.10.1`
- [Upstream Flowseal release](https://github.com/Flowseal/zapret-discord-youtube/releases/tag/1.10.1)
- [Release ZIP](https://github.com/Flowseal/zapret-discord-youtube/releases/download/1.10.1/zapret-discord-youtube-1.10.1.zip)
- SHA-256: `f748d61fec75e4edc992cb5b09d554e914197c68c690384aceb61f143d8f76c9`

> **Do not merge this PR without completing manual testing.** This automation only proposes a managed-channel update; it does not approve or merge it.

## Manual test checklist

- [ ] Ядро скачивается и устанавливается
- [ ] Временный режим запуска работает
- [ ] Режим службы Windows работает
- [ ] Выбранная стратегия сохраняется после обновления
- [ ] Пользовательские списки сохраняются
- [ ] Откат на предыдущую версию работает
- [ ] После отката восстанавливается выбранная стратегия
- [ ] Приложение нормально запускается после перезагрузки
